### PR TITLE
settings.xml saved to %AppData%

### DIFF
--- a/FTPbox/Classes/Settings.cs
+++ b/FTPbox/Classes/Settings.cs
@@ -10,7 +10,7 @@ namespace FTPbox.Classes
     public class Settings
     {
         XmlDocument xmlDocument = new XmlDocument();
-        string documentPath = Application.StartupPath + "\\settings.xml";
+        string documentPath = Application.UserAppDataPath + "\\settings.xml";
 
         public  Settings()
         { 


### PR DESCRIPTION
Modified the location where settings.xml will be saved to fix the [settings.xml access denied](https://github.com/JohnTheGr8/FTPbox/issues/2) bug issued earlier today.

This fixed the requirement that the application is run as an administrator under Windows Vista and 7 in order for the settings file to be saved and read.
