### PR TITLE
several improvements, syntax corrections and bugfixes

### DIFF
--- a/FTPboxLib/Common.cs
+++ b/FTPboxLib/Common.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Utilities.Encryption;
 
 namespace FTPboxLib
 {
@@ -46,7 +47,7 @@ namespace FTPboxLib
         /// </summary>
         public static string Encrypt(string password)
         {
-            return Utilities.Encryption.AESEncryption.Encrypt(password, DecryptionPassword, DecryptionSalt);
+            return AESEncryption.Encrypt(password, DecryptionPassword, DecryptionSalt);
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace FTPboxLib
         /// </summary>
         public static string Decrypt(string encrypted)
         {
-            return Utilities.Encryption.AESEncryption.Decrypt(encrypted, DecryptionPassword, DecryptionSalt);
+            return AESEncryption.Decrypt(encrypted, DecryptionPassword, DecryptionSalt);
         }
 
         /// <summary>
@@ -83,9 +84,9 @@ namespace FTPboxLib
         public static string _name(string path)
         {
             if (path.Contains("/"))
-                path = path.Substring(path.LastIndexOf("/"));
+                path = path.Substring(path.LastIndexOf("/", StringComparison.Ordinal));
             if (path.Contains(@"\"))
-                path = path.Substring(path.LastIndexOf(@"\"));
+                path = path.Substring(path.LastIndexOf(@"\", StringComparison.Ordinal));
             if (path.StartsWith("/") || path.StartsWith(@"\"))
                 path = path.Substring(1);
             return path;
@@ -100,12 +101,12 @@ namespace FTPboxLib
         public static string _tempName(string cpath, string prefix)
         {
             if (!cpath.Contains("/") && !cpath.Contains(@"\"))
-                return String.Format("{0}{1}", prefix, cpath);
+                return string.Format("{0}{1}", prefix, cpath);
 
-            string parent = cpath.Substring(0, cpath.LastIndexOf("/"));
-            string temp_name = String.Format("{0}{1}", prefix, _name(cpath));
+            var parent = cpath.Substring(0, cpath.LastIndexOf("/", StringComparison.Ordinal));
+            var tempName = string.Format("{0}{1}", prefix, _name(cpath));
 
-            return String.Format("{0}/{1}", parent, temp_name);
+            return string.Format("{0}/{1}", parent, tempName);
         }
 
         /// <summary>
@@ -117,9 +118,9 @@ namespace FTPboxLib
         public static string _tempLocal(string lpath, string prefix)
         {
             lpath = lpath.ReplaceSlashes();
-            string parent = lpath.Substring(0, lpath.LastIndexOf("/"));            
+            var parent = lpath.Substring(0, lpath.LastIndexOf("/", StringComparison.Ordinal));            
 
-            return String.Format("{0}/{1}{2}", parent, prefix, _name(lpath));
+            return string.Format("{0}/{1}{2}", parent, prefix, _name(lpath));
         }
 
         /// <summary>
@@ -178,7 +179,7 @@ namespace FTPboxLib
                 if (stream != null)
                     stream.Close();
             }
-            if (!String.IsNullOrWhiteSpace(name))
+            if (!string.IsNullOrWhiteSpace(name))
                 Log.Write(l.Debug, "File {0} is locked: False", name);
             return false;
         }

--- a/FTPboxLib/Console/aConsole.cs
+++ b/FTPboxLib/Console/aConsole.cs
@@ -8,8 +8,9 @@
 
 using System;
 using System.IO;
-using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
 
 namespace FTPboxLib
 {
@@ -26,12 +27,11 @@ namespace FTPboxLib
         public static void Allocate()
         {
             AllocConsole();
-            IntPtr stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-            SafeFileHandle safeFileHandle = new SafeFileHandle(stdHandle, true);
-            FileStream fileStream = new FileStream(safeFileHandle, FileAccess.Write);
-            System.Text.Encoding encoding = System.Text.Encoding.GetEncoding(MY_CODE_PAGE);
-            StreamWriter standardOutput = new StreamWriter(fileStream, encoding);
-            standardOutput.AutoFlush = true;
+            var stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            var safeFileHandle = new SafeFileHandle(stdHandle, true);
+            var fileStream = new FileStream(safeFileHandle, FileAccess.Write);
+            var encoding = Encoding.GetEncoding(MY_CODE_PAGE);
+            var standardOutput = new StreamWriter(fileStream, encoding) {AutoFlush = true};
             Console.SetOut(standardOutput);
         }
     }

--- a/FTPboxLib/EventArgs.cs
+++ b/FTPboxLib/EventArgs.cs
@@ -62,7 +62,7 @@ namespace FTPboxLib
         /// <summary>
         /// TransferProgressArgs constructor.
         /// </summary>
-        /// <param name="transfered">bytes transferred</param>
+        /// <param name="transferred">bytes transferred</param>
         /// <param name="total">total bytes transferred</param>
         /// <param name="item">the transferred item</param>
         /// <param name="started">when the transfer started</param>
@@ -95,7 +95,7 @@ namespace FTPboxLib
                var f = rate <= 1024 ? "bytes" : "kb";
                if (rate > 1024) rate /= 1024;
 
-               Console.Write("\r Transferred {0:p} bytes @ {1} {2}/s", (double)TotalTransferred / (double)Item.Item.Size, rate, f);
+               Console.Write("\r Transferred {0:p} bytes @ {1} {2}/s", TotalTransferred / (double)Item.Item.Size, rate, f);
 
                return string.Format("{0} {1}/s", rate, f);
            }

--- a/FTPboxLib/INIclass.cs
+++ b/FTPboxLib/INIclass.cs
@@ -1,11 +1,11 @@
-﻿using System.Text;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
+using System.Text;
 
 namespace FTPbox.Classes
 {
     internal class IniFile
     {
-        public string path;
+        public string Path;
 
         [DllImport("kernel32")]
         private static extern long WritePrivateProfileString(string section,
@@ -16,20 +16,20 @@ namespace FTPbox.Classes
           string key, string def, StringBuilder retVal,
           int size, string filePath);
 
-        public IniFile(string INIPath)
+        public IniFile(string iniPath)
         {
-            path = INIPath;
+            Path = iniPath;
         }
 
-        public void WriteValue(string Section, string Key, string Value)
+        public void WriteValue(string section, string key, string value)
         {
-            WritePrivateProfileString(Section, Key, Value, this.path);
+            WritePrivateProfileString(section, key, value, Path);
         }
 
-        public string ReadValue(string Section, string Key)
+        public string ReadValue(string section, string key)
         {
-            StringBuilder temp = new StringBuilder(255);
-            int i = GetPrivateProfileString(Section, Key, "", temp, 255, this.path);
+            var temp = new StringBuilder(255);
+            var i = GetPrivateProfileString(section, key, "", temp, 255, Path);
             return temp.ToString();
         }
     }

--- a/FTPboxLib/IgnoreList.cs
+++ b/FTPboxLib/IgnoreList.cs
@@ -29,7 +29,7 @@ namespace FTPboxLib
 	    public List<string> Extensions = new List<string>();     //list of extensions to be ignored
 
         [JsonProperty("Dotfiles")]
-	    public bool IgnoreDotFiles = false; //ignore dotfiles?
+	    public bool IgnoreDotFiles; //ignore dotfiles?
 
         [JsonProperty("Tempfiles")]
 	    public bool IgnoreTempFiles = true; //ignore temporary files?
@@ -38,8 +38,6 @@ namespace FTPboxLib
 	    public DateTime LastModifiedMinimum = DateTime.MinValue; //the minimum modification datetime
         
 	    #endregion
-
-		public IgnoreList() { }
 
         /// <summary>
         /// Saves the current filter settings to the settings file
@@ -69,8 +67,8 @@ namespace FTPboxLib
         /// <returns>True if the path matches the ignore filters</returns>
         public bool IsIgnored(string path)
         {
-            string name = Common._name(path);
-            string ext = name.Contains(".") ? name.Substring(name.LastIndexOf(".") + 1) : null;
+            var name = Common._name(path);
+            var ext = name.Contains(".") ? name.Substring(name.LastIndexOf(".", StringComparison.Ordinal) + 1) : null;
 
             return
                 // are dotfiles ignored?
@@ -92,9 +90,7 @@ namespace FTPboxLib
         public bool isInIgnoredFolders(string path)
         {
             if (Items.Count <= 0) return false;
-            if (Items.Contains(path)) return true;
-
-            return Items.Any(f => path.StartsWith(f + "/") && !string.IsNullOrWhiteSpace(f));
+            return Items.Contains(path) || Items.Any(f => path.StartsWith(f + "/") && !string.IsNullOrWhiteSpace(f));
         }
 	}
 }

--- a/FTPboxLib/Profile.cs
+++ b/FTPboxLib/Profile.cs
@@ -43,7 +43,7 @@ namespace FTPboxLib
 
 	    public void AddAccount(string host, string user, string pass, int port)
 	    {
-	        Account = new Account()
+	        Account = new Account
 	        {
                 Host = host,
                 Username = user,
@@ -56,7 +56,7 @@ namespace FTPboxLib
 
 	    public void AddPaths(string remote, string local, string http)
 	    {
-            Paths = new Paths()
+            Paths = new Paths
             {
                 Remote = remote,
 	            Local = local, 
@@ -74,25 +74,19 @@ namespace FTPboxLib
 
         #region Serialization
 
-        private string tmpPassword = string.Empty;
+        private string _tmpPassword = string.Empty;
 
         [OnSerializing]
         internal void OnSerializing(StreamingContext context)
         {
-            tmpPassword = Account.Password;
-            if (AskForPassword)
-                Account.Password = string.Empty;
-            else
-                Account.Password = Common.Encrypt(Account.Password);
+            _tmpPassword = Account.Password;
+            Account.Password = AskForPassword ? string.Empty : Common.Encrypt(Account.Password);
         }
 
         [OnSerialized]
         internal void OnSerialized(StreamingContext context)
         {
-            if (AskForPassword)
-                Account.Password = tmpPassword;
-            else
-                Account.Password = Common.Decrypt(Account.Password);
+            Account.Password = AskForPassword ? _tmpPassword : Common.Decrypt(Account.Password);
         }
 
         [OnDeserialized]

--- a/FTPboxLib/Properties/AssemblyInfo.cs
+++ b/FTPboxLib/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/FTPboxLib/Settings.cs
+++ b/FTPboxLib/Settings.cs
@@ -12,10 +12,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
-using Formatting = Newtonsoft.Json.Formatting;
 
 namespace FTPboxLib
 {
@@ -25,9 +24,9 @@ namespace FTPboxLib
         #region Fields
 
         // Paths to our configuration files
-        private static readonly string confProfiles = Path.Combine(Common.AppdataFolder, "profiles.conf");
-        private static readonly string confGeneral = Path.Combine(Common.AppdataFolder, "general.conf");
-        private static readonly string confCertificates = Path.Combine(Common.AppdataFolder, "trusted_certificates.conf");
+        private static readonly string ConfProfiles = Path.Combine(Common.AppdataFolder, "profiles.conf");
+        private static readonly string ConfGeneral = Path.Combine(Common.AppdataFolder, "general.conf");
+        private static readonly string ConfCertificates = Path.Combine(Common.AppdataFolder, "trusted_certificates.conf");
 
         public static SettingsGeneral General;
         public static List<AccountController> Profiles;
@@ -42,9 +41,9 @@ namespace FTPboxLib
 
         public static void Load()
         {
-            Log.Write(l.Debug, "Settings file path: {0}", confGeneral);
-            Log.Write(l.Debug, "Profiles file path: {0}", confProfiles);
-            Log.Write(l.Debug, "Certificates file path: {0}", confCertificates);
+            Log.Write(l.Debug, "Settings file path: {0}", ConfGeneral);
+            Log.Write(l.Debug, "Profiles file path: {0}", ConfProfiles);
+            Log.Write(l.Debug, "Certificates file path: {0}", ConfCertificates);
 
             if (!Directory.Exists(Common.AppdataFolder)) Directory.CreateDirectory(Common.AppdataFolder);
 
@@ -54,24 +53,24 @@ namespace FTPboxLib
 
             Profiles.Add(new AccountController());
 
-            if (!File.Exists(confGeneral)) return;
+            if (!File.Exists(ConfGeneral)) return;
             // Load General Settings
-            string config = File.ReadAllText(confGeneral);
-            if (!String.IsNullOrWhiteSpace(config))
+            var config = File.ReadAllText(ConfGeneral);
+            if (!string.IsNullOrWhiteSpace(config))
                 General = (SettingsGeneral)JsonConvert.DeserializeObject(config, typeof(SettingsGeneral));
             
-            if (!File.Exists(confProfiles)) return;
+            if (!File.Exists(ConfProfiles)) return;
             // Load Profiles
-            config = File.ReadAllText(confProfiles);
-            if (!String.IsNullOrWhiteSpace(config))
+            config = File.ReadAllText(ConfProfiles);
+            if (!string.IsNullOrWhiteSpace(config))
                 Profiles = (List<AccountController>)JsonConvert.DeserializeObject(config, typeof(List<AccountController>));
 
             //TODO: Profile.Load();
 
-            if (!File.Exists(confCertificates)) return;
+            if (!File.Exists(ConfCertificates)) return;
             // Load trusted certificates
-            config = File.ReadAllText(confCertificates);
-            if (!String.IsNullOrWhiteSpace(config))
+            config = File.ReadAllText(ConfCertificates);
+            if (!string.IsNullOrWhiteSpace(config))
                 TrustedCertificates = (List<string>)JsonConvert.DeserializeObject(config, typeof(List<string>));
 
             Log.Write(l.Info, "Settings Loaded.");
@@ -94,9 +93,9 @@ namespace FTPboxLib
         /// </summary>
         public static void SaveGeneral()
         {
-            string config_gen = JsonConvert.SerializeObject(General, Formatting.Indented);
+            var configGen = JsonConvert.SerializeObject(General, Formatting.Indented);
 
-            File.WriteAllText(confGeneral, config_gen);
+            File.WriteAllText(ConfGeneral, configGen);
         }
 
         /// <summary>
@@ -112,8 +111,8 @@ namespace FTPboxLib
             else
                 Profiles[General.DefaultProfile] = def;
 
-            string config_prof = JsonConvert.SerializeObject(Profiles, Formatting.Indented);
-            File.WriteAllText(confProfiles, config_prof);
+            var configProf = JsonConvert.SerializeObject(Profiles, Formatting.Indented);
+            File.WriteAllText(ConfProfiles, configProf);
         }
 
         /// <summary>
@@ -122,7 +121,7 @@ namespace FTPboxLib
         public static void SaveCertificates()
         {
             var conf = JsonConvert.SerializeObject(TrustedCertificates, Formatting.Indented);
-            File.WriteAllText(confCertificates, conf);
+            File.WriteAllText(ConfCertificates, conf);
         }
 
         /// <summary>
@@ -154,11 +153,11 @@ namespace FTPboxLib
             SaveGeneral();
             if (Profiles.Count == 0)
             {
-                File.Delete(confProfiles);
+                File.Delete(ConfProfiles);
                 return;
             }
-            string config_prof = JsonConvert.SerializeObject(Profiles, Formatting.Indented);
-            File.WriteAllText(confProfiles, config_prof);
+            var config_prof = JsonConvert.SerializeObject(Profiles, Formatting.Indented);
+            File.WriteAllText(ConfProfiles, config_prof);
         }
 
         #endregion
@@ -172,10 +171,7 @@ namespace FTPboxLib
         {
             get
             {
-                if (Profiles.Count <= General.DefaultProfile)
-                    return new AccountController();
-
-                return Profiles[General.DefaultProfile];
+                return Profiles.Count <= General.DefaultProfile ? new AccountController() : Profiles[General.DefaultProfile];
             }
             set
             {
@@ -186,7 +182,7 @@ namespace FTPboxLib
 
         public static string[] ProfileTitles
         {
-            get { return Profiles.Select(p => String.Format("{0}@{1}", p.Account.Username, p.Account.Host)).ToArray(); }
+            get { return Profiles.Select(p => string.Format("{0}@{1}", p.Account.Username, p.Account.Host)).ToArray(); }
         }
 
         #endregion        
@@ -205,7 +201,7 @@ namespace FTPboxLib
         
         public int UploadLimit = 0;
 
-        public int DefaultProfile = 0;
+        public int DefaultProfile;
 
         public bool EnableLogging = true;
 

--- a/FTPboxLib/SyncQueue.cs
+++ b/FTPboxLib/SyncQueue.cs
@@ -25,16 +25,16 @@ namespace FTPboxLib
 {
     public class SyncQueue : List<SyncQueueItem>
     {
-        private List<SyncQueueItem> CompletedList = new List<SyncQueueItem>();
+        private readonly List<SyncQueueItem> _completedList = new List<SyncQueueItem>();
         private Thread _rcThread;
         // Timer used to schedule automatic syncing according to user's preferences
         private Timer _tSync;
 
-        private AccountController controller;
+        private readonly AccountController _controller;
 
         public SyncQueue(AccountController account)
         {
-            this.controller = account;
+            _controller = account;
             account.WebInterface.InterfaceRemoved += (o, e) =>
             {
                 if (account.Account.SyncMethod == SyncMethod.Automatic) SetTimer();
@@ -67,49 +67,49 @@ namespace FTPboxLib
                     goto StartSync;
                 }
             }
-            else if (item.ActionType == ChangeAction.deleted)
+            else switch (item.ActionType)
             {
-                foreach (var i in this.ToList().Where(x => x.NewCommonPath == item.CommonPath))
-                {
-                    if (i.ActionType == ChangeAction.renamed)
+                case ChangeAction.deleted:
+                    foreach (var i in this.ToList().Where(x => x.NewCommonPath == item.CommonPath))
                     {
-                        base[base.IndexOf(i)].ActionType = ChangeAction.deleted;
-                        base[base.IndexOf(i)].SkipNotification = true;
+                        if (i.ActionType == ChangeAction.renamed)
+                        {
+                            base[IndexOf(i)].ActionType = ChangeAction.deleted;
+                            base[IndexOf(i)].SkipNotification = true;
+                        }
+                        else
+                            Remove(i);
                     }
-                    else
-                        base.Remove(i);
-                }
-            }
-            else if (item.ActionType == ChangeAction.renamed)
-            {
-                foreach (var i in this.ToList().Where(x => x.NewCommonPath == item.CommonPath && x.ActionType == ChangeAction.renamed))
-                {
-                    base[base.IndexOf(i)].Item.NewFullPath = item.Item.NewFullPath;
-                }
-                foreach (var i in this.ToList().Where(x => x.CommonPath == item.CommonPath))
-                {
-                    if (i.ActionType == ChangeAction.changed || i.ActionType == ChangeAction.created)
+                    break;
+                case ChangeAction.renamed:
+                    foreach (var i in this.ToList().Where(x => x.NewCommonPath == item.CommonPath && x.ActionType == ChangeAction.renamed))
                     {
-                        // Delete old file
-                        base[base.IndexOf(i)].ActionType = ChangeAction.deleted;
-                        // Convert new item to ChangeAction : create
-                        item.ActionType = ChangeAction.created;
-                        item.Item.FullPath = item.Item.NewFullPath;
+                        base[IndexOf(i)].Item.NewFullPath = item.Item.NewFullPath;
                     }
-                }
-            }
-            else // if ChangeAction is Update
-            {
-                foreach (var i in this.ToList().Where(x => x.NewCommonPath == item.CommonPath))
-                {
-                    if (i.ActionType == ChangeAction.renamed)
+                    foreach (var i in this.ToList().Where(x => x.CommonPath == item.CommonPath))
                     {
-                        base[base.IndexOf(i)].ActionType = ChangeAction.deleted;
-                        base[base.IndexOf(i)].AddedOn = DateTime.Now;
+                        if (i.ActionType == ChangeAction.changed || i.ActionType == ChangeAction.created)
+                        {
+                            // Delete old file
+                            base[IndexOf(i)].ActionType = ChangeAction.deleted;
+                            // Convert new item to ChangeAction : create
+                            item.ActionType = ChangeAction.created;
+                            item.Item.FullPath = item.Item.NewFullPath;
+                        }
                     }
-                    else
-                        base.RemoveAt(base.IndexOf(i));
-                }
+                    break;
+                default:
+                    foreach (var i in this.ToList().Where(x => x.NewCommonPath == item.CommonPath))
+                    {
+                        if (i.ActionType == ChangeAction.renamed)
+                        {
+                            base[IndexOf(i)].ActionType = ChangeAction.deleted;
+                            base[IndexOf(i)].AddedOn = DateTime.Now;
+                        }
+                        else
+                            RemoveAt(IndexOf(i));
+                    }
+                    break;
             }
 
             item.AddedOn = DateTime.Now;
@@ -140,8 +140,8 @@ namespace FTPboxLib
 
             foreach (var item in Items)
             {
-                if ((controller.Account.SyncDirection == SyncDirection.Local && item.SyncTo == SyncTo.Remote) ||
-                    (controller.Account.SyncDirection == SyncDirection.Remote && item.SyncTo == SyncTo.Local))
+                if ((_controller.Account.SyncDirection == SyncDirection.Local && item.SyncTo == SyncTo.Remote) ||
+                    (_controller.Account.SyncDirection == SyncDirection.Remote && item.SyncTo == SyncTo.Local))
                 {
                     item.SkipNotification = true;
                     RemoveLast(StatusType.Skipped);
@@ -176,16 +176,16 @@ namespace FTPboxLib
             // Update the FileLog with all latest changes
 
             Log.Write(l.Info, "Found in completed list:");
-            foreach (var d in CompletedList.Where(x => x.Status == StatusType.Success))
+            foreach (var d in _completedList.Where(x => x.Status == StatusType.Success))
             {
-                Log.Write(l.Info, string.Format("{0,-40} {1,-10}", d.NewCommonPath, d.Status.ToString()));
+                Log.Write(l.Info, string.Format("{0,-40} {1,-10}", d.NewCommonPath, d.Status));
             }
 
             // Notifications time
 
-            int folders = CompletedList.Count(x => x.Item.Type == ClientItemType.Folder && x.Status == StatusType.Success && !x.SkipNotification);
-            int files = CompletedList.Count(x => x.Item.Type == ClientItemType.File && x.Status == StatusType.Success && !x.SkipNotification);
-            int failed = CompletedList.Count(x => x.Status == StatusType.Failure);
+            var folders = _completedList.Count(x => x.Item.Type == ClientItemType.Folder && x.Status == StatusType.Success && !x.SkipNotification);
+            var files = _completedList.Count(x => x.Item.Type == ClientItemType.File && x.Status == StatusType.Success && !x.SkipNotification);
+            var failed = _completedList.Count(x => x.Status == StatusType.Failure);
 
             Log.Write(l.Info, "###############################");
             Log.Write(l.Info, "{0} files successfully synced", files);
@@ -197,7 +197,7 @@ namespace FTPboxLib
                 Notifications.Show(files, folders);
             else if (folders == 1 && files == 0)
             {
-                var lastFolder = CompletedList.Last(x => x.Item.Type == ClientItemType.Folder && x.Status == StatusType.Success && !x.SkipNotification);
+                var lastFolder = _completedList.Last(x => x.Item.Type == ClientItemType.Folder && x.Status == StatusType.Success && !x.SkipNotification);
                 if (lastFolder.ActionType == ChangeAction.renamed)
                     Notifications.Show( Common._name(lastFolder.CommonPath), ChangeAction.renamed, Common._name(lastFolder.NewCommonPath));
                 else
@@ -208,7 +208,7 @@ namespace FTPboxLib
                 Notifications.Show(folders, false);
             else if (folders == 0 && files == 1)
             {
-                var lastFile = CompletedList.Last(x => x.Item.Type == ClientItemType.File && x.Status == StatusType.Success && !x.SkipNotification);
+                var lastFile = _completedList.Last(x => x.Item.Type == ClientItemType.File && x.Status == StatusType.Success && !x.SkipNotification);
                 if (lastFile.ActionType == ChangeAction.renamed)
                     Notifications.Show( Common._name(lastFile.CommonPath), ChangeAction.renamed, Common._name(lastFile.NewCommonPath));
                 else
@@ -219,20 +219,20 @@ namespace FTPboxLib
 
             // print completed list
             const string frmt = "{0, -9}{1, -20}{2, -8}{3, -8}{4, -7}";
-            string head = string.Format(frmt, "Added On", "Common Path", "Action", "SyncTo", "Status");
+            var head = string.Format(frmt, "Added On", "Common Path", "Action", "SyncTo", "Status");
             Log.Write(l.Info, head);
-            foreach (var i in CompletedList.OrderBy(x=>x.AddedOn))
-                Log.Write(l.Info, string.Format(frmt, i.AddedOn.FormatDate(), i.CommonPath, i.ActionType.ToString(), i.SyncTo.ToString(), i.Status.ToString()));
+            foreach (var i in _completedList.OrderBy(x=>x.AddedOn))
+                Log.Write(l.Info, string.Format(frmt, i.AddedOn.FormatDate(), i.CommonPath, i.ActionType, i.SyncTo, i.Status));
 
-            CompletedList.RemoveAll(x => x.Status != StatusType.Waiting);
-            controller.LoadLocalFolders();
+            _completedList.RemoveAll(x => x.Status != StatusType.Waiting);
+            _controller.LoadLocalFolders();
 
             // Check for any pending WebUI actions
-            if (controller.WebInterface.DeletePending || controller.WebInterface.UpdatePending)
-                controller.WebInterface.Update();
+            if (_controller.WebInterface.DeletePending || _controller.WebInterface.UpdatePending)
+                _controller.WebInterface.Update();
             else
             {
-                if (controller.Account.SyncMethod == SyncMethod.Automatic) SetTimer();
+                if (_controller.Account.SyncMethod == SyncMethod.Automatic) SetTimer();
                 Running = false;
             }
         }               
@@ -243,7 +243,7 @@ namespace FTPboxLib
         /// <param name="status"></param>
         public void RemoveLast(StatusType status)
         {
-            CompletedList.Add(new SyncQueueItem (controller)
+            _completedList.Add(new SyncQueueItem (_controller)
             { 
                 Status = status, 
                 Item = Next.Item, 
@@ -255,26 +255,37 @@ namespace FTPboxLib
             // Add last item to FileLog
             if (status == StatusType.Success)
             {
-                if (Next.Item.Type == ClientItemType.Folder)
+                switch (Next.Item.Type)
                 {
-                    if (Next.ActionType == ChangeAction.deleted)
-                        controller.FileLog.removeFolder(Next.CommonPath);
-                    else if (Next.ActionType == ChangeAction.renamed)
-                        controller.FileLog.putFolder(Next.NewCommonPath, Next.CommonPath);
-                    else
-                        controller.FileLog.putFolder(Next.CommonPath);
-                }
-                else if (Next.Item.Type == ClientItemType.File)
-                {
-                    if (Next.ActionType == ChangeAction.deleted)
-                        controller.RemoveFromLog(Next.CommonPath);
-                    else if (Next.ActionType == ChangeAction.renamed)
-                    {
-                        controller.RemoveFromLog(Next.CommonPath);
-                        controller.FileLog.putFile(Next);
-                    }
-                    else
-                        controller.FileLog.putFile(Next);
+                    case ClientItemType.Folder:
+                        switch (Next.ActionType)
+                        {
+                            case ChangeAction.deleted:
+                                _controller.FileLog.RemoveFolder(Next.CommonPath);
+                                break;
+                            case ChangeAction.renamed:
+                                _controller.FileLog.PutFolder(Next.NewCommonPath, Next.CommonPath);
+                                break;
+                            default:
+                                _controller.FileLog.PutFolder(Next.CommonPath);
+                                break;
+                        }
+                        break;
+                    case ClientItemType.File:
+                        switch (Next.ActionType)
+                        {
+                            case ChangeAction.deleted:
+                                _controller.RemoveFromLog(Next.CommonPath);
+                                break;
+                            case ChangeAction.renamed:
+                                _controller.RemoveFromLog(Next.CommonPath);
+                                _controller.FileLog.PutFile(Next);
+                                break;
+                            default:
+                                _controller.FileLog.PutFile(Next);
+                                break;
+                        }
+                        break;
                 }
             }
             // Remove from queue
@@ -287,7 +298,7 @@ namespace FTPboxLib
         /// </summary>
         private void SetTimer()
         {
-            _tSync = new Timer(state => this.Add(new SyncQueueItem (controller)
+            _tSync = new Timer(state => Add(new SyncQueueItem (_controller)
             {
                 Item = new ClientItem
                 {
@@ -300,7 +311,7 @@ namespace FTPboxLib
                 ActionType = ChangeAction.changed,
                 SyncTo = SyncTo.Local,
                 SkipNotification = true
-            }), null, 1000 * controller.Account.SyncFrequency, 0);
+            }), null, 1000 * _controller.Account.SyncFrequency, 0);
         }
 
         #endregion
@@ -312,11 +323,11 @@ namespace FTPboxLib
         /// </summary>
         private void CheckLocalFolder(SyncQueueItem folder)
         {
-            if (!controller.ItemGetsSynced(folder.CommonPath) && folder.CommonPath != ".") return;
+            if (!_controller.ItemGetsSynced(folder.CommonPath) && folder.CommonPath != ".") return;
 
-            string cp = (folder.Item.FullPath == controller.Paths.Local) ? "." : folder.CommonPath;
+            var cp = (folder.Item.FullPath == _controller.Paths.Local) ? "." : folder.CommonPath;
 
-            bool cpExists = cp == "." || controller.Client.Exists(cp);
+            var cpExists = cp == "." || _controller.Client.Exists(cp);
 
             if (!cpExists)
             {
@@ -324,25 +335,25 @@ namespace FTPboxLib
                 base.Add(folder);
             }
 
-            var RemoteFilesList = cpExists ? new List<string>(controller.Client.ListRecursive(cp).Select(x => x.FullPath)) : new List<string>();
-            RemoteFilesList = RemoteFilesList.ConvertAll(x => controller.GetCommonPath(x, false));
+            var remoteFilesList = cpExists ? new List<string>(_controller.Client.ListRecursive(cp).Select(x => x.FullPath)) : new List<string>();
+            remoteFilesList = remoteFilesList.ConvertAll(x => _controller.GetCommonPath(x, false));
 
-            if (controller.Client.ListingFailed)
+            if (_controller.Client.ListingFailed)
             {
                 folder.Status = StatusType.Failure;
                 folder.CompletedOn = DateTime.Now;
-                CompletedList.Add(folder);
-                controller.Client.Reconnect();
+                _completedList.Add(folder);
+                _controller.Client.Reconnect();
                 return;
             }
             
             var di = new DirectoryInfo(folder.LocalPath);
-            foreach (var d in di.GetDirectories("*", SearchOption.AllDirectories).Where(x => !RemoteFilesList.Contains(controller.GetCommonPath(x.FullName, true))))
+            foreach (var d in di.GetDirectories("*", SearchOption.AllDirectories).Where(x => !remoteFilesList.Contains(_controller.GetCommonPath(x.FullName, true))))
             {
-                if (!controller.ItemGetsSynced(d.FullName, true)) continue;
+                if (!_controller.ItemGetsSynced(d.FullName, true)) continue;
 
                 // TODO: Base add instead?
-                Add(new SyncQueueItem (controller)
+                Add(new SyncQueueItem (_controller)
                 {
                     Item = new ClientItem{
                         Name = d.Name,
@@ -359,12 +370,12 @@ namespace FTPboxLib
 
             foreach (var f in di.GetFiles("*", SearchOption.AllDirectories))
             {
-                string cpath = controller.GetCommonPath(f.FullName, true);
-                if (!controller.ItemGetsSynced(cpath)) continue;
+                var cpath = _controller.GetCommonPath(f.FullName, true);
+                if (!_controller.ItemGetsSynced(cpath)) continue;
 
-                if (!RemoteFilesList.Contains(cpath) || controller.FileLog.getLocal(cpath) != f.LastWriteTime)
+                if (!remoteFilesList.Contains(cpath) || _controller.FileLog.GetLocal(cpath) != f.LastWriteTime)
                     // TODO: Base add instead?
-                    Add(new SyncQueueItem(controller)
+                    Add(new SyncQueueItem(_controller)
                     {
                         Item = new ClientItem
                         {
@@ -390,27 +401,29 @@ namespace FTPboxLib
             {
                 if (item.SyncTo == SyncTo.Local)
                 {
-                    controller.FolderWatcher.Pause();   // Pause watchers
-                    if (item.Item.Type == ClientItemType.File)
-                        #if __MonoCs__
-                        File.Delete(item.LocalPath);
-                        #else
-                        FileIO.FileSystem.DeleteFile(item.LocalPath, FileIO.UIOption.OnlyErrorDialogs, FileIO.RecycleOption.SendToRecycleBin);
-                        #endif
-                    else if (item.Item.Type == ClientItemType.Folder)
-                        #if __MonoCs__
-                        Directory.Delete(item.LocalPath, true);
-                        #else
-                        FileIO.FileSystem.DeleteDirectory(item.LocalPath, FileIO.UIOption.OnlyErrorDialogs, FileIO.RecycleOption.SendToRecycleBin);
-                        #endif
-                    controller.FolderWatcher.Resume();  // Resume watchers
+                    _controller.FolderWatcher.Pause();   // Pause watchers
+                    switch (item.Item.Type)
+                    {
+                        case ClientItemType.File:
+                            FileIO.FileSystem.DeleteFile(item.LocalPath, FileIO.UIOption.OnlyErrorDialogs, FileIO.RecycleOption.SendToRecycleBin);
+                            break;
+                        case ClientItemType.Folder:
+                            FileIO.FileSystem.DeleteDirectory(item.LocalPath, FileIO.UIOption.OnlyErrorDialogs, FileIO.RecycleOption.SendToRecycleBin);
+                            break;
+                    }
+                    _controller.FolderWatcher.Resume();  // Resume watchers
                 }
                 else
                 {
-                    if (item.Item.Type == ClientItemType.File)
-                        controller.Client.Remove(item.CommonPath);
-                    else if (item.Item.Type == ClientItemType.Folder)
-                        controller.Client.RemoveFolder(item.CommonPath);
+                    switch (item.Item.Type)
+                    {
+                        case ClientItemType.File:
+                            _controller.Client.Remove(item.CommonPath);
+                            break;
+                        case ClientItemType.Folder:
+                            _controller.Client.RemoveFolder(item.CommonPath);
+                            break;
+                    }
                 }
                 // Success?
                 RemoveLast(StatusType.Success);
@@ -419,7 +432,7 @@ namespace FTPboxLib
             {
                 Common.LogError(ex);
                 RemoveLast(StatusType.Failure);
-                controller.FolderWatcher.Resume();      // Resume watchers
+                _controller.FolderWatcher.Resume();      // Resume watchers
             }
         }
 
@@ -434,13 +447,13 @@ namespace FTPboxLib
                 Log.Write(l.Client, "Renaming: {0} into {1}", item.CommonPath, item.NewCommonPath);
                 // Cannot detect remote renaming, atleast not yet
                 if (item.SyncTo == SyncTo.Remote)
-                    controller.Client.Rename(item.CommonPath, item.NewCommonPath);
+                    _controller.Client.Rename(item.CommonPath, item.NewCommonPath);
                 // Success?
                 RemoveLast(StatusType.Success);
             }
             catch
             {
-                if (!controller.Client.Exists(item.CommonPath) && controller.Client.Exists(item.NewCommonPath))
+                if (!_controller.Client.Exists(item.CommonPath) && _controller.Client.Exists(item.NewCommonPath))
                     RemoveLast(StatusType.Success);
                 else
                     RemoveLast(StatusType.Failure);
@@ -453,15 +466,15 @@ namespace FTPboxLib
         /// </summary>
         private void CheckUpdateItem(SyncQueueItem item)
         {
-            TransferStatus _status;
+            TransferStatus status;
             if (item.Item.Type == ClientItemType.File)
             {
-                _status = (item.SyncTo == SyncTo.Remote) ? controller.Client.SafeUpload(item) : CheckExistingFile(item);
+                status = (item.SyncTo == SyncTo.Remote) ? _controller.Client.SafeUpload(item) : CheckExistingFile(item);
 
-                if (_status == TransferStatus.None)
-                    base.RemoveAt(0);
+                if (status == TransferStatus.None)
+                    RemoveAt(0);
                 else
-                    RemoveLast(_status == TransferStatus.Success ? StatusType.Success : StatusType.Failure);
+                    RemoveLast(status == TransferStatus.Success ? StatusType.Success : StatusType.Failure);
                                    
                 return;
             }
@@ -469,7 +482,7 @@ namespace FTPboxLib
             {
                 try
                 {
-                    controller.Client.MakeFolder(item.CommonPath);
+                    _controller.Client.MakeFolder(item.CommonPath);
                     RemoveLast(StatusType.Success);
                 }
                 catch
@@ -480,24 +493,24 @@ namespace FTPboxLib
             }
             // else: Folder, Sync to local
             Notifications.ChangeTrayText(MessageType.Listing);
-            var AllItems = new List<ClientItem>();
+            var allItems = new List<ClientItem>();
             Log.Write(l.Debug, "Syncing remote folder {0} to local", item.CommonPath);
 
-            if (!controller.Client.CheckWorkingDirectory())
+            if (!_controller.Client.CheckWorkingDirectory())
             {
                 RemoveLast(StatusType.Failure); 
                 return;
             }
 
-            foreach (var f in controller.Client.ListRecursive(item.CommonPath))
+            foreach (var f in _controller.Client.ListRecursive(item.CommonPath))
             {
-                AllItems.Add(f);
-                string cpath = controller.GetCommonPath(f.FullPath, false);
-                string lpath = Path.Combine(controller.Paths.Local, cpath);
+                allItems.Add(f);
+                var cpath = _controller.GetCommonPath(f.FullPath, false);
+                var lpath = Path.Combine(_controller.Paths.Local, cpath);
 
-                if (!controller.ItemGetsSynced(cpath)) continue;
+                if (!_controller.ItemGetsSynced(cpath)) continue;
 
-                var sqi = new SyncQueueItem(controller)
+                var sqi = new SyncQueueItem(_controller)
                     {
                         Status = StatusType.Success,
                         Item = f,
@@ -507,60 +520,61 @@ namespace FTPboxLib
                         SyncTo = SyncTo.Local
                     };
 
-                if (f.Type == ClientItemType.Folder)
+                switch (f.Type)
                 {
-                    if (this.Any(x => x.CommonPath == sqi.CommonPath && x.ActionType == ChangeAction.deleted && x.SyncTo == SyncTo.Remote))                    
-                        continue;
+                    case ClientItemType.Folder:
+                        if (this.Any(x => x.CommonPath == sqi.CommonPath && x.ActionType == ChangeAction.deleted && x.SyncTo == SyncTo.Remote))                    
+                            continue;
                     
-                    if (!Directory.Exists(lpath))
-                    {
-                        controller.FolderWatcher.Pause();       // Pause Watchers
-                        Directory.CreateDirectory(lpath);
-                        controller.FolderWatcher.Resume();      // Resume Watchers
+                        if (!Directory.Exists(lpath))
+                        {
+                            _controller.FolderWatcher.Pause();       // Pause Watchers
+                            Directory.CreateDirectory(lpath);
+                            _controller.FolderWatcher.Resume();      // Resume Watchers
+                            sqi.CompletedOn = DateTime.Now;
+                            sqi.Status = StatusType.Success;
+                            _completedList.Add(sqi);
+                            // Add to log
+                            _controller.FileLog.PutFolder(sqi.CommonPath);
+                        }
+                        break;
+                    case ClientItemType.File:
+                        if (this.Any(x => (x.CommonPath == sqi.CommonPath || sqi.CommonPath.StartsWith(x.CommonPath))
+                                          && x.ActionType == ChangeAction.deleted && x.SyncTo == SyncTo.Remote))
+                            continue;
+
+                        status = !File.Exists(lpath) ? _controller.Client.SafeDownload(sqi) : CheckExistingFile(sqi);
+
+                        if (status == TransferStatus.None) continue;
+
+                        sqi.Status = status == TransferStatus.Success ? StatusType.Success : StatusType.Failure;
                         sqi.CompletedOn = DateTime.Now;
-                        sqi.Status = StatusType.Success;
-                        CompletedList.Add(sqi);
+                        _completedList.Add(sqi);
                         // Add to log
-                        controller.FileLog.putFolder(sqi.CommonPath);
-                    }
-                }
-                else if (f.Type == ClientItemType.File)
-                {
-                    if (this.Any(x => (x.CommonPath == sqi.CommonPath || sqi.CommonPath.StartsWith(x.CommonPath))
-                                    && x.ActionType == ChangeAction.deleted && x.SyncTo == SyncTo.Remote))
-                        continue;
-
-                    _status = !File.Exists(lpath) ? controller.Client.SafeDownload(sqi) : CheckExistingFile(sqi);
-
-                    if (_status == TransferStatus.None) continue;
-
-                    sqi.Status = _status == TransferStatus.Success ? StatusType.Success : StatusType.Failure;
-                    sqi.CompletedOn = DateTime.Now;
-                    CompletedList.Add(sqi);
-                    // Add to log
-                    if (sqi.Status == StatusType.Success)
-                        controller.FileLog.putFile(sqi);
+                        if (sqi.Status == StatusType.Success)
+                            _controller.FileLog.PutFile(sqi);
+                        break;
                 }
             }
-            if (controller.Client.ListingFailed)
+            if (_controller.Client.ListingFailed)
             {
                 RemoveLast(StatusType.Failure);
-                controller.Client.Reconnect();
+                _controller.Client.Reconnect();
                 return;
             }
 
             // Look for local files that should be deleted
             foreach (var local in new DirectoryInfo(item.LocalPath).GetFiles("*", SearchOption.AllDirectories))
             {
-                var cpath = controller.GetCommonPath(local.FullName, true);
+                var cpath = _controller.GetCommonPath(local.FullName, true);
                 // continue if the file is ignored
-                if (!controller.ItemGetsSynced(cpath)) continue;
+                if (!_controller.ItemGetsSynced(cpath)) continue;
                 // continue if the file was found in the remote list
-                if (AllItems.Any(x => controller.GetCommonPath(x.FullPath, false) == cpath)) continue;
+                if (allItems.Any(x => _controller.GetCommonPath(x.FullPath, false) == cpath)) continue;
                 // continue if the file is not in the log, or is changed compared to the logged data TODO: Maybe send to remote folder?
-                if (controller.FileLog.Files.All(x => x.CommonPath != cpath) ||
-                    controller.FileLog.Files.Find(x => x.CommonPath == cpath).Local != local.LastWriteTime)
-                    Add(new SyncQueueItem(controller)
+                if (_controller.FileLog.Files.All(x => x.CommonPath != cpath) ||
+                    _controller.FileLog.Files.Find(x => x.CommonPath == cpath).Local != local.LastWriteTime)
+                    Add(new SyncQueueItem(_controller)
                     {
                         Item = new ClientItem
                         {
@@ -575,7 +589,7 @@ namespace FTPboxLib
                     });
                 else
                     // Seems like the file was deleted from the remote folder
-                    Add(new SyncQueueItem(controller)
+                    Add(new SyncQueueItem(_controller)
                     {
                         Item = new ClientItem
                         {
@@ -592,20 +606,20 @@ namespace FTPboxLib
             // Look for local folders that should be deleted
             foreach (var local in new DirectoryInfo(item.LocalPath).GetDirectories("*", SearchOption.AllDirectories))
             {
-                var cpath = controller.GetCommonPath(local.FullName, true);
+                var cpath = _controller.GetCommonPath(local.FullName, true);
                 // continue if the folder is ignored
-                if (!controller.ItemGetsSynced(cpath)) continue;
+                if (!_controller.ItemGetsSynced(cpath)) continue;
                 // continue if the folder was found in the remote list
-                if (AllItems.Any(x => controller.GetCommonPath(x.FullPath, false) == cpath)) continue;
+                if (allItems.Any(x => _controller.GetCommonPath(x.FullPath, false) == cpath)) continue;
                 // continue if the folder is not in the log TODO: Maybe send to remote folder?
-                if (controller.FileLog.Folders.All(x => x != cpath)) continue;
+                if (_controller.FileLog.Folders.All(x => x != cpath)) continue;
 
                 // Seems like the folder was deleted from the remote folder
-                Add(new SyncQueueItem(controller)
+                Add(new SyncQueueItem(_controller)
                 {
                     Item = new ClientItem
                     {
-                        FullPath = controller.GetCommonPath(local.FullName, true),
+                        FullPath = _controller.GetCommonPath(local.FullName, true),
                         Name = local.Name,
                         Type = ClientItemType.Folder,
                         LastWriteTime = DateTime.MinValue, // Doesn't matter
@@ -623,34 +637,34 @@ namespace FTPboxLib
         /// </summary>
         private TransferStatus CheckExistingFile(SyncQueueItem item)
         {
-            DateTime locLwt = File.GetLastWriteTime(item.LocalPath);
-            DateTime remLwt = (controller.Account.Protocol != FtpProtocol.SFTP) ? controller.Client.GetLwtOf(item.CommonPath) : item.Item.LastWriteTime;
+            var locLwt = File.GetLastWriteTime(item.LocalPath);
+            var remLwt = (_controller.Account.Protocol != FtpProtocol.SFTP) ? _controller.Client.GetLwtOf(item.CommonPath) : item.Item.LastWriteTime;
             
-            DateTime locLog = controller.FileLog.getLocal(item.CommonPath);
-            DateTime remLog = controller.FileLog.getRemote(item.CommonPath);
+            var locLog = _controller.FileLog.GetLocal(item.CommonPath);
+            var remLog = _controller.FileLog.GetRemote(item.CommonPath);
 
-            int rResult = DateTime.Compare(remLwt, remLog);
-            int lResult = DateTime.Compare(locLwt, locLog);
-            int bResult = DateTime.Compare(remLwt, locLwt);
+            var rResult = DateTime.Compare(remLwt, remLog);
+            var lResult = DateTime.Compare(locLwt, locLog);
+            var bResult = DateTime.Compare(remLwt, locLwt);
 
-            TimeSpan remDif = remLwt - remLog;
-            TimeSpan locDif = locLwt - locLog;
+            var remDif = remLwt - remLog;
+            var locDif = locLwt - locLog;
 
             // Set to TransferStatus.None by default, incase none of the following
             // conditions are met (which means the file is up-to-date already)
-            var _status = TransferStatus.None;
+            var status = TransferStatus.None;
 
             if (rResult > 0 && lResult > 0 && remDif.TotalSeconds > 1 && locDif.TotalSeconds > 1)
             {
                 if (remDif.TotalSeconds > locDif.TotalSeconds)
-                    _status = controller.Client.SafeDownload(item);                                    
+                    status = _controller.Client.SafeDownload(item);                                    
             }
             else if (rResult > 0 && remDif.TotalSeconds > 1)
-                _status = controller.Client.SafeDownload(item);
+                status = _controller.Client.SafeDownload(item);
             if (lResult > 0 && locDif.TotalSeconds > 1)
             {
                 Log.Write(l.Warning, "{0} seems to have escaped startup check", item.CommonPath);
-                Add(new SyncQueueItem(controller)
+                Add(new SyncQueueItem(_controller)
                 {
                     Item = new ClientItem
                     {
@@ -666,7 +680,7 @@ namespace FTPboxLib
                 });
             }
 
-            return _status;
+            return status;
         }
 
         #endregion
@@ -677,7 +691,7 @@ namespace FTPboxLib
         {
             get
             {
-                while (base.Count > 0)
+                while (Count > 0)
                     yield return Next;
             }
         }

--- a/FTPboxLib/SyncQueueItem.cs
+++ b/FTPboxLib/SyncQueueItem.cs
@@ -11,6 +11,7 @@
  */
 
 using System;
+using System.IO;
 
 namespace FTPboxLib
 {
@@ -20,7 +21,7 @@ namespace FTPboxLib
 
         public SyncQueueItem(AccountController account)
         {
-            this.controller = account;
+            controller = account;
         }
 
         /// <summary>
@@ -77,8 +78,7 @@ namespace FTPboxLib
             {
                 if (CommonPath.Length <= Common._name(CommonPath).Length + 1)
                     return string.Empty;
-                else
-                    return CommonPath.Substring(0, CommonPath.Length - Common._name(CommonPath).Length - 1);
+                return CommonPath.Substring(0, CommonPath.Length - Common._name(CommonPath).Length - 1);
             }
         }
 
@@ -86,7 +86,7 @@ namespace FTPboxLib
         {
             get
             {
-                return SyncTo == SyncTo.Remote ? Item.FullPath : System.IO.Path.Combine(controller.Paths.Local, CommonPath);
+                return SyncTo == SyncTo.Remote ? Item.FullPath : Path.Combine(controller.Paths.Local, CommonPath);
             }
         }
     }

--- a/FTPboxLib/Translations.cs
+++ b/FTPboxLib/Translations.cs
@@ -12,20 +12,20 @@
 
 using System;
 using System.Collections.Generic;
-using System.Xml;
 using System.Linq;
+using System.Xml;
 
 namespace FTPboxLib
 {
     public class Translations
     {
-        XmlDocument xmlDocument = new XmlDocument();       
-        string documentPath = Environment.CurrentDirectory + "\\translations.xml";
+        readonly XmlDocument _xmlDocument = new XmlDocument();
+        readonly string _documentPath = Environment.CurrentDirectory + "\\translations.xml";
 
         public Translations()
         {
-            try { xmlDocument.Load(documentPath); }
-            catch (Exception ex) { Log.Write(l.Info, "?>" + ex.Message); xmlDocument.LoadXml("<translations></translations>"); }
+            try { _xmlDocument.Load(_documentPath); }
+            catch (Exception ex) { Log.Write(l.Info, "?>" + ex.Message); _xmlDocument.LoadXml("<translations></translations>"); }
         }
 
         public string this[MessageType t]
@@ -120,7 +120,7 @@ namespace FTPboxLib
         {
             get
             {
-                string fileorfolder = (file) ? this[MessageType.File] : this[MessageType.Folder];
+                var fileorfolder = (file) ? this[MessageType.File] : this[MessageType.Folder];
                 switch (ca)
                 {
                     case ChangeAction.created:
@@ -347,9 +347,8 @@ namespace FTPboxLib
         public string Get(string xPath, string defaultValue, string lan = null)
         {
             var path = string.Format("translations/{0}{1}", lan ?? Settings.General.Language, xPath);
-            XmlNode xmlNode = xmlDocument.SelectSingleNode(path);
-            if (xmlNode != null) { return xmlNode.InnerText.Replace("_and", "&"); }
-            else { return defaultValue; }
+            var xmlNode = _xmlDocument.SelectSingleNode(path);
+            return xmlNode != null ? xmlNode.InnerText.Replace("_and", "&") : defaultValue;
         }
 
         /// <summary>
@@ -357,9 +356,17 @@ namespace FTPboxLib
         /// </summary>
         public List<string> GetPaths()
         {
-            return xmlDocument.SelectNodes("translations/en/*/*").Cast<XmlNode>()
-                .Select(x => string.Format("/{0}/{1}", x.ParentNode.Name, x.Name))
-                .ToList();
+            if (_xmlDocument != null)
+            {
+                var nodes = _xmlDocument.SelectNodes("translations/en/*/*");
+                if (nodes != null)
+                {
+                    var result = nodes.Cast<XmlNode>()
+                        .Select(x => x.ParentNode != null ? string.Format("/{0}/{1}", x.ParentNode.Name, x.Name) : null);
+                    return result.ToList();
+                }
+            }
+            return new List<string>();
         }
         
         #endregion

--- a/Windows/FTPbox/Forms/fMain.cs
+++ b/Windows/FTPbox/Forms/fMain.cs
@@ -12,40 +12,43 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Windows.Forms;
-using System.Runtime.InteropServices;
-using System.Net;
-using System.IO;
 using System.Diagnostics;
-using System.Net.NetworkInformation;
-using System.Threading;
-using Microsoft.Win32;
+using System.Drawing;
+using System.IO;
 using System.IO.Pipes;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Windows.Forms;
+using FTPbox.Properties;
 using FTPboxLib;
+using Microsoft.Win32;
+using Newtonsoft.Json;
+using Settings = FTPboxLib.Settings;
+using Timer = System.Threading.Timer;
 
 namespace FTPbox.Forms
 {
     public partial class fMain : Form
     {
-        public bool gotpaths = false;                       //if the paths have been set or checked
-        private bool changedfromcheck = true;
-
+        private bool _changedfromcheck = true;
+        private fSelectiveSync _fSelective;
         //Form instances
-        private Setup fSetup;
-        private Translate ftranslate;
-        private fSelectiveSync fSelective;
-        private fTrayForm fTrayForm;
+        private Setup _fSetup;
+        private Translate _ftranslate;
+        private fTrayForm _fTrayForm;
 
         private TrayTextNotificationArgs _lastTrayStatus = new TrayTextNotificationArgs
-            {AssossiatedFile = null, MessageType = MessageType.AllSynced};
-        
-        private System.Threading.Timer tRetry;
+        {AssossiatedFile = null, MessageType = MessageType.AllSynced};
 
+        private Timer _tRetry;
+        public bool GotPaths; //if the paths have been set or checked
         //Links
-        public string link = string.Empty;                  //The web link of the last-changed file
-        public string locLink = string.Empty;               //The local path to the last-changed file
+        public string Link = string.Empty; //The web link of the last-changed file
+        public string LocLink = string.Empty; //The local path to the last-changed file
 
         public fMain()
         {
@@ -55,8 +58,8 @@ namespace FTPbox.Forms
 
         private void fMain_Load(object sender, EventArgs e)
         {
-            NetworkChange.NetworkAddressChanged += OnNetworkChange;            
-            
+            NetworkChange.NetworkAddressChanged += OnNetworkChange;
+
             //TODO: Should this stay?
             Program.Account.LoadLocalFolders();
 
@@ -64,64 +67,68 @@ namespace FTPbox.Forms
                 Log.DebugEnabled = true;
 
             Notifications.NotificationReady += (o, n) =>
-                {
-                    link = Program.Account.LinkToRecent();
-                    tray.ShowBalloonTip(100, n.Title, n.Text, ToolTipIcon.Info);
-                };
+            {
+                Link = Program.Account.LinkToRecent();
+                tray.ShowBalloonTip(100, n.Title, n.Text, ToolTipIcon.Info);
+            };
 
-            Program.Account.Client.ConnectionClosed += (o, n) => Log.Write(l.Warning, "Connection closed: {0}", n.Text ?? string.Empty);
+            Program.Account.Client.ConnectionClosed +=
+                (o, n) => Log.Write(l.Warning, "Connection closed: {0}", n.Text ?? string.Empty);
 
-            Program.Account.Client.ReconnectingFailed += (o, n) => Log.Write(l.Warning, "Reconnecting failed"); //TODO: Use this...
+            Program.Account.Client.ReconnectingFailed += (o, n) => Log.Write(l.Warning, "Reconnecting failed");
+            //TODO: Use this...
 
             Program.Account.Client.ValidateCertificate += CheckCertificate;
 
             Program.Account.WebInterface.UpdateFound += (o, n) =>
+            {
+                const string msg = "A new version of the web interface is available, do you want to upgrade to it?";
+                if (
+                    MessageBox.Show(msg, "FTPbox - WebUI Update", MessageBoxButtons.YesNo, MessageBoxIcon.Information) ==
+                    DialogResult.Yes)
                 {
-                    const string msg = "A new version of the web interface is available, do you want to upgrade to it?";
-                    if (MessageBox.Show(msg, "FTPbox - WebUI Update", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes)
-                    {
-                        Program.Account.WebInterface.UpdatePending = true;
-                        Program.Account.WebInterface.Update();
-                    }
-                };
+                    Program.Account.WebInterface.UpdatePending = true;
+                    Program.Account.WebInterface.Update();
+                }
+            };
             Program.Account.WebInterface.InterfaceRemoved += (o, n) =>
+            {
+                Invoke(new MethodInvoker(() =>
                 {
-                    this.Invoke(new MethodInvoker(() =>
-                    {
-                        chkWebInt.Enabled = true;
-                        labViewInBrowser.Enabled = false;
-                    }));
-                    link = string.Empty;
-                };
+                    chkWebInt.Enabled = true;
+                    labViewInBrowser.Enabled = false;
+                }));
+                Link = string.Empty;
+            };
             Program.Account.WebInterface.InterfaceUploaded += (o, n) =>
+            {
+                Invoke(new MethodInvoker(() =>
                 {
-                    this.Invoke(new MethodInvoker(() =>
-                    {
-                        chkWebInt.Enabled = true;
-                        labViewInBrowser.Enabled = true;
-                    }));
-                    link = Program.Account.WebInterfaceLink;
-                };
+                    chkWebInt.Enabled = true;
+                    labViewInBrowser.Enabled = true;
+                }));
+                Link = Program.Account.WebInterfaceLink;
+            };
 
-            Notifications.TrayTextNotification += (o,n) => this.Invoke(new MethodInvoker(() => SetTray(o,n)));
+            Notifications.TrayTextNotification += (o, n) => Invoke(new MethodInvoker(() => SetTray(o, n)));
 
-            fSetup = new Setup {Tag = this};
-            ftranslate = new Translate {Tag = this};
-            fSelective = new fSelectiveSync();
-            fTrayForm = new fTrayForm() {Tag = this};
-            
+            _fSetup = new Setup {Tag = this};
+            _ftranslate = new Translate {Tag = this};
+            _fSelective = new fSelectiveSync();
+            _fTrayForm = new fTrayForm {Tag = this};
+
             if (!string.IsNullOrEmpty(Settings.General.Language))
                 Set_Language(Settings.General.Language);
-            
+
             StartUpWork();
 
             CheckForUpdate();
         }
 
         /// <summary>
-        /// Work done at the application startup. 
-        /// Checks the saved account info, updates the form controls and starts syncing if syncing is automatic.
-        /// If there's no internet connection, puts the program to offline mode.
+        ///     Work done at the application startup.
+        ///     Checks the saved account info, updates the form controls and starts syncing if syncing is automatic.
+        ///     If there's no internet connection, puts the program to offline mode.
         /// </summary>
         private void StartUpWork()
         {
@@ -131,8 +138,8 @@ namespace FTPbox.Forms
             if (ConnectedToInternet())
             {
                 CheckAccount();
-                
-                this.Invoke(new MethodInvoker(UpdateDetails));
+
+                Invoke(new MethodInvoker(UpdateDetails));
 
                 if (OfflineMode) return;
 
@@ -141,7 +148,7 @@ namespace FTPbox.Forms
                 CheckPaths();
                 Log.Write(l.Debug, "Paths: OK");
 
-                this.Invoke(new MethodInvoker(UpdateDetails));
+                Invoke(new MethodInvoker(UpdateDetails));
 
                 if (!Settings.IsNoMenusMode)
                 {
@@ -151,36 +158,36 @@ namespace FTPbox.Forms
             else
             {
                 OfflineMode = true;
-                SetTray(null, new TrayTextNotificationArgs { MessageType = MessageType.Offline });
+                SetTray(null, new TrayTextNotificationArgs {MessageType = MessageType.Offline});
             }
         }
 
         /// <summary>
-        /// checks if account's information used the last time has changed
+        ///     checks if account's information used the last time has changed
         /// </summary>
         private void CheckAccount()
         {
-            if (!Program.Account.isAccountSet || Program.Account.isPasswordRequired)
+            if (!Program.Account.IsAccountSet || Program.Account.IsPasswordRequired)
             {
                 Log.Write(l.Info, "Will open New FTP form.");
-                Setup.JustPassword = Program.Account.isPasswordRequired;
-                
-                fSetup.ShowDialog();
+                Setup.JustPassword = Program.Account.IsPasswordRequired;
+
+                _fSetup.ShowDialog();
 
                 Log.Write(l.Info, "Done");
 
-                this.Show();
+                Show();
             }
-            else if (Program.Account.isAccountSet)
+            else if (Program.Account.IsAccountSet)
                 try
                 {
                     Program.Account.Client.Connect();
 
-                    this.Invoke(new MethodInvoker(() =>
+                    Invoke(new MethodInvoker(() =>
                     {
-                        this.ShowInTaskbar = false;
-                        this.Hide();
-                        this.ShowInTaskbar = true;
+                        ShowInTaskbar = false;
+                        Hide();
+                        ShowInTaskbar = true;
                     }));
                 }
                 catch (Exception ex)
@@ -189,40 +196,40 @@ namespace FTPbox.Forms
                     Common.LogError(ex);
 
                     OfflineMode = true;
-                    SetTray(null, new TrayTextNotificationArgs { MessageType = MessageType.Offline });
+                    SetTray(null, new TrayTextNotificationArgs {MessageType = MessageType.Offline});
 
-                    tRetry = new System.Threading.Timer(state => this.StartUpWork(), null, 30000, 0);                    
+                    _tRetry = new Timer(state => StartUpWork(), null, 30000, 0);
                 }
         }
-        
+
         /// <summary>
-        /// checks if paths used the last time still exist
+        ///     checks if paths used the last time still exist
         /// </summary>
         public void CheckPaths()
         {
-            if (!Program.Account.isPathsSet)
+            if (!Program.Account.IsPathsSet)
             {
-                fSetup.ShowDialog();       
-                this.Show();
+                _fSetup.ShowDialog();
+                Show();
 
-                if (!gotpaths)
+                if (!GotPaths)
                 {
                     Log.Write(l.Debug, "bb cruel world");
                     KillTheProcess();
                 }
             }
             else
-                gotpaths = true;
-            
+                GotPaths = true;
+
             Program.Account.LoadLocalFolders();
         }
-        
+
         /// <summary>
-        /// Updates the form's labels etc
+        ///     Updates the form's labels etc
         /// </summary>
         public void UpdateDetails()
         {
-            Log.Write(l.Debug, "Updating the form details");            
+            Log.Write(l.Debug, "Updating the form details");
 
             chkStartUp.Checked = CheckStartup();
 
@@ -238,7 +245,7 @@ namespace FTPbox.Forms
                 rOpenLocal.Checked = true;
 
             //  Account Tab     //
-            
+
             cProfiles.Items.Clear();
             cProfiles.Items.AddRange(Settings.ProfileTitles);
             cProfiles.SelectedIndex = Settings.General.DefaultProfile;
@@ -257,7 +264,7 @@ namespace FTPbox.Forms
             lVersion.Text = Application.ProductVersion.Substring(0, 5) + @" Beta";
 
             //   Filters Tab    //
-            
+
             cIgnoreDotfiles.Checked = Program.Account.IgnoreList.IgnoreDotFiles;
             cIgnoreTempFiles.Checked = Program.Account.IgnoreList.IgnoreTempFiles;
 
@@ -287,12 +294,12 @@ namespace FTPbox.Forms
             chkWebInt.Enabled = !OfflineMode;
             SyncToolStripMenuItem.Enabled = !OfflineMode;
 
-            if (OfflineMode || !gotpaths) return;
+            if (OfflineMode || !GotPaths) return;
 
-            bool e = Program.Account.WebInterface.Exists;
+            var e = Program.Account.WebInterface.Exists;
             chkWebInt.Checked = e;
             labViewInBrowser.Enabled = e;
-            changedfromcheck = false;
+            _changedfromcheck = false;
 
             Program.Account.FolderWatcher.Setup();
 
@@ -300,25 +307,25 @@ namespace FTPbox.Forms
             new Thread(() =>
             {
                 // ...check local folder for changes
-                string cpath = Program.Account.GetCommonPath(Program.Account.Paths.Local, true);
-                Program.Account.SyncQueue.Add(new SyncQueueItem (Program.Account)
+                var cpath = Program.Account.GetCommonPath(Program.Account.Paths.Local, true);
+                Program.Account.SyncQueue.Add(new SyncQueueItem(Program.Account)
+                {
+                    Item = new ClientItem
                     {
-                        Item = new ClientItem
-                            {
-                                FullPath = Program.Account.Paths.Local,
-                                Name = Common._name(cpath),
-                                Type = ClientItemType.Folder,
-                                Size = 0x0,
-                                LastWriteTime = DateTime.MinValue
-                            },
-                        ActionType = ChangeAction.changed,
-                        SyncTo = SyncTo.Remote
-                    });
+                        FullPath = Program.Account.Paths.Local,
+                        Name = Common._name(cpath),
+                        Type = ClientItemType.Folder,
+                        Size = 0x0,
+                        LastWriteTime = DateTime.MinValue
+                    },
+                    ActionType = ChangeAction.changed,
+                    SyncTo = SyncTo.Remote
+                });
             }).Start();
         }
 
         /// <summary>
-        /// Fill the combo-box of available translations.
+        ///     Fill the combo-box of available translations.
         /// </summary>
         private void PopulateLanguages()
         {
@@ -331,7 +338,7 @@ namespace FTPbox.Forms
         }
 
         /// <summary>
-        /// Kills the current process. Called from the tray menu.
+        ///     Kills the current process. Called from the tray menu.
         /// </summary>
         public void KillTheProcess()
         {
@@ -344,7 +351,7 @@ namespace FTPbox.Forms
             try
             {
                 tray.Visible = false;
-                Process.GetCurrentProcess().Kill();                
+                Process.GetCurrentProcess().Kill();
             }
             catch
             {
@@ -352,10 +359,205 @@ namespace FTPbox.Forms
             }
         }
 
+        #region Update System
+
+        /// <summary>
+        ///     checks for an update
+        ///     called on each start-up of FTPbox.
+        /// </summary>
+        private void CheckForUpdate()
+        {
+            try
+            {
+                var wc = new WebClient();
+                wc.DownloadStringCompleted += (o, e) =>
+                {
+                    if (e.Cancelled || e.Error != null) return;
+
+                    var json =
+                        (Dictionary<string, string>)
+                            JsonConvert.DeserializeObject(e.Result, typeof (Dictionary<string, string>));
+                    var version = json["NewVersion"];
+
+                    //  Check that the downloaded file has the correct version format, using regex.
+                    if (Regex.IsMatch(version, @"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"))
+                    {
+                        Log.Write(l.Debug, "Current Version: {0} Installed Version: {1}", version,
+                            Application.ProductVersion);
+
+                        if (version == Application.ProductVersion) return;
+
+                        // show dialog box for  download now, learn more and remind me next time
+                        var nvform = new newversion {Tag = this};
+                        newversion.Newvers = json["NewVersion"];
+                        newversion.DownLink = json["DownloadLink"];
+                        nvform.ShowDialog();
+                        Show();
+                    }
+                };
+                // Find out what the latest version is
+                wc.DownloadStringAsync(new Uri(@"http://ftpbox.org/winversion.json"));
+            }
+            catch (Exception ex)
+            {
+                Log.Write(l.Debug, "Error with version checking");
+                Common.LogError(ex);
+            }
+        }
+
+        #endregion
+
+        private void bTranslate_Click(object sender, EventArgs e)
+        {
+            _ftranslate.ShowDialog();
+        }
+
+        public void SetTray(object o, TrayTextNotificationArgs e)
+        {
+            try
+            {
+                // Save latest tray status
+                _lastTrayStatus = e;
+
+                switch (e.MessageType)
+                {
+                    case MessageType.Connecting:
+                    case MessageType.Reconnecting:
+                    case MessageType.Syncing:
+                        tray.Icon = Resources.syncing;
+                        tray.Text = Common.Languages[e.MessageType];
+                        break;
+                    case MessageType.Uploading:
+                    case MessageType.Downloading:
+                        tray.Icon = Resources.syncing;
+                        tray.Text = Common.Languages[MessageType.Syncing];
+                        break;
+                    case MessageType.AllSynced:
+                    case MessageType.Ready:
+                        tray.Icon = Resources.AS;
+                        tray.Text = Common.Languages[e.MessageType];
+                        break;
+                    case MessageType.Offline:
+                    case MessageType.Disconnected:
+                        tray.Icon = Resources.offline1;
+                        tray.Text = Common.Languages[e.MessageType];
+                        break;
+                    case MessageType.Listing:
+                        tray.Icon = Resources.AS;
+                        tray.Text = (Program.Account.Account.SyncMethod == SyncMethod.Automatic)
+                            ? Common.Languages[MessageType.AllSynced]
+                            : Common.Languages[MessageType.Listing];
+                        break;
+                    case MessageType.Nothing:
+                        tray.Icon = Resources.ftpboxnew;
+                        tray.Text = Common.Languages[e.MessageType];
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Common.LogError(ex);
+            }
+        }
+
+        /// <summary>
+        ///     Starts the remote-to-local syncing on the root folder.
+        ///     Called from the timer, when remote syncing is automatic.
+        /// </summary>
+        /// <param name="state"></param>
+        public void StartRemoteSync(object state)
+        {
+            if (Program.Account.Account.SyncMethod == SyncMethod.Automatic) SyncToolStripMenuItem.Enabled = false;
+            Log.Write(l.Debug, "Starting remote sync...");
+            Program.Account.SyncQueue.Add(new SyncQueueItem(Program.Account)
+            {
+                Item = new ClientItem
+                {
+                    FullPath = (string) state,
+                    Name = (string) state,
+                    Type = ClientItemType.Folder,
+                    Size = 0x0,
+                    LastWriteTime = DateTime.Now
+                },
+                ActionType = ChangeAction.changed,
+                SyncTo = SyncTo.Local,
+                SkipNotification = true
+            });
+        }
+
+        /// <summary>
+        ///     Display a messagebox with the certificate details, ask user to approve/decline it.
+        /// </summary>
+        public static void CheckCertificate(object sender, ValidateCertificateEventArgs n)
+        {
+            var msg = string.Empty;
+            // Add certificate info
+            if (Program.Account.Account.Protocol == FtpProtocol.SFTP)
+                msg += string.Format("{0,-8}\t {1}\n{2,-8}\t {3}\n", "Key:", n.Key, "Key Size:", n.KeySize);
+            else
+                msg += string.Format("{0,-25}\t {1}\n{2,-25}\t {3}\n{4,-25}\t {5}\n{6,-25}\t {7}\n\n",
+                    "Valid from:", n.ValidFrom, "Valid to:", n.ValidTo, "Serial number:", n.SerialNumber, "Algorithm:",
+                    n.Algorithm);
+
+            msg += string.Format("Fingerprint: {0}\n\n", n.Fingerprint);
+            msg += "Trust this certificate and continue?";
+
+            // Do we trust the server's certificate?
+            var certificateTrusted =
+                MessageBox.Show(msg, "Do you trust this certificate?", MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Information) == DialogResult.Yes;
+            n.IsTrusted = certificateTrusted;
+
+            if (certificateTrusted)
+            {
+                Settings.TrustedCertificates.Add(n.Fingerprint);
+                Settings.SaveCertificates();
+            }
+        }
+
+        private void fMain_RightToLeftLayoutChanged(object sender, EventArgs e)
+        {
+            RightToLeft = RightToLeftLayout ? RightToLeft.Yes : RightToLeft.No;
+            // Inherit manually
+            tabControl1.RightToLeftLayout = RightToLeftLayout;
+            trayMenu.RightToLeft = RightToLeftLayout ? RightToLeft.Yes : RightToLeft.No;
+
+            // Relocate controls where necessary
+            cLanguages.Location = RightToLeftLayout ? new Point(267, 19) : new Point(9, 19);
+            bTranslate.Location = RightToLeftLayout ? new Point(172, 17) : new Point(191, 17);
+            bBrowseLogs.Location = RightToLeftLayout ? new Point(172, 61) : new Point(191, 61);
+
+            bAddAccount.Location = new Point(RightToLeftLayout ? 14 : 299, 10);
+            bRemoveAccount.Location = new Point(RightToLeftLayout ? 95 : 380, 10);
+            cProfiles.Location = new Point(RightToLeftLayout ? 170 : 8, 11);
+            bConfigureAccount.Location = new Point(RightToLeftLayout ? 6 : 325, 16);
+
+            bConfigureSelectiveSync.Location = new Point(RightToLeftLayout ? 6 : 325, 19);
+            bConfigureExtensions.Location = new Point(RightToLeftLayout ? 6 : 325, 48);
+
+            //bRefresh.Location = new Point(RightToLeftLayout ? 9 : 352, 19);
+            nSyncFrequency.Location = RightToLeftLayout ? new Point(344, 89) : new Point(35, 89);
+            nDownLimit.Location = RightToLeftLayout ? new Point(344, 45) : new Point(35, 45);
+            nUpLimit.Location = RightToLeftLayout ? new Point(344, 100) : new Point(35, 100);
+
+            lVersion.Location = RightToLeftLayout ? new Point(100, 21) : new Point(272, 21);
+            linkLabel3.Location = RightToLeftLayout ? new Point(100, 44) : new Point(272, 44);
+            linkLabel4.Location = RightToLeftLayout ? new Point(100, 67) : new Point(272, 67);
+            label21.Location = RightToLeftLayout ? new Point(100, 90) : new Point(272, 90);
+            labSupportMail.Location = RightToLeftLayout ? new Point(100, 113) : new Point(272, 113);
+            label19.Location = RightToLeftLayout ? new Point(100, 136) : new Point(272, 136);
+
+            labCurVersion.Location = RightToLeftLayout ? new Point(272, 21) : new Point(100, 21);
+            labTeam.Location = RightToLeftLayout ? new Point(272, 44) : new Point(100, 44);
+            labSite.Location = RightToLeftLayout ? new Point(272, 21) : new Point(100, 71);
+            labContact.Location = RightToLeftLayout ? new Point(272, 90) : new Point(100, 90);
+            labLangUsed.Location = RightToLeftLayout ? new Point(272, 136) : new Point(100, 136);
+        }
+
         #region translations
 
         /// <summary>
-        /// Translate all controls and stuff to the given language.
+        ///     Translate all controls and stuff to the given language.
         /// </summary>
         /// <param name="lan">The language to translate to in 2-letter format</param>
         private void Set_Language(string lan)
@@ -363,7 +565,7 @@ namespace FTPbox.Forms
             Settings.General.Language = lan;
             Log.Write(l.Debug, "Changing language to: {0}", lan);
 
-            this.Text = "FTPbox | " + Common.Languages[UiControl.Options];
+            Text = "FTPbox | " + Common.Languages[UiControl.Options];
             //general tab
             tabGeneral.Text = Common.Languages[UiControl.General];
             gLinks.Text = Common.Languages[UiControl.Links];
@@ -371,8 +573,8 @@ namespace FTPbox.Forms
             rOpenInBrowser.Text = Common.Languages[UiControl.OpenUrl];
             rCopy2Clipboard.Text = Common.Languages[UiControl.CopyUrl];
             rOpenLocal.Text = Common.Languages[UiControl.OpenLocal];
-                        
-            gApp.Text = Common.Languages[UiControl.Application];                        
+
+            gApp.Text = Common.Languages[UiControl.Application];
             chkShowNots.Text = Common.Languages[UiControl.ShowNotifications];
             chkStartUp.Text = Common.Languages[UiControl.StartOnStartup];
             chkEnableLogging.Text = Common.Languages[UiControl.EnableLogging];
@@ -395,7 +597,7 @@ namespace FTPbox.Forms
             labTempPrefix.Text = Common.Languages[UiControl.TempNamePrefix];
 
             //filters tab
-            tabFilters.Text = Common.Languages[UiControl.Filters];            
+            tabFilters.Text = Common.Languages[UiControl.Filters];
             gFileFilters.Text = Common.Languages[UiControl.Filters];
             bConfigureSelectiveSync.Text = Common.Languages[UiControl.Configure];
             bConfigureExtensions.Text = Common.Languages[UiControl.Configure];
@@ -441,7 +643,7 @@ namespace FTPbox.Forms
 
             SetTray(null, _lastTrayStatus);
 
-            fTrayForm.Set_Language();
+            _fTrayForm.Set_Language();
 
             // Is this a right-to-left language?
             RightToLeftLayout = Common.RtlLanguages.Contains(lan);
@@ -452,28 +654,33 @@ namespace FTPbox.Forms
         }
 
         /// <summary>
-        /// When the user changes to another language, translate every label etc to that language.
+        ///     When the user changes to another language, translate every label etc to that language.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void cLanguages_SelectedIndexChanged(object sender, EventArgs e)
         {
-            string lan = cLanguages.SelectedItem.ToString().Substring(cLanguages.SelectedItem.ToString().IndexOf("(") + 1);
+            var lan =
+                cLanguages.SelectedItem.ToString()
+                    .Substring(cLanguages.SelectedItem.ToString().IndexOf("(", StringComparison.Ordinal) + 1);
             lan = lan.Substring(0, lan.Length - 1);
             try
             {
                 Set_Language(lan);
             }
-            catch { }
+            catch
+            {
+            }
         }
 
-        #endregion        
+        #endregion
 
         #region check internet connection
 
-        private bool OfflineMode = false;
-        [DllImport("wininet.dll")]        
-        private extern static bool InternetGetConnectedState(out int Description, int ReservedValue);
+        private bool OfflineMode;
+
+        [DllImport("wininet.dll")]
+        private static extern bool InternetGetConnectedState(out int description, int reservedValue);
 
         public void OnNetworkChange(object sender, EventArgs e)
         {
@@ -498,65 +705,22 @@ namespace FTPbox.Forms
                         fswFolders.Dispose();
                     }
                     OfflineMode = true;
-                    SetTray(null, new TrayTextNotificationArgs { MessageType = MessageType.Offline });
+                    SetTray(null, new TrayTextNotificationArgs {MessageType = MessageType.Offline});
                 }
             }
-            catch { }
+            catch
+            {
+            }
         }
 
         /// <summary>
-        /// Check if internet connection is available
+        ///     Check if internet connection is available
         /// </summary>
         /// <returns></returns>
         public static bool ConnectedToInternet()
         {
-            int Desc;
-            return InternetGetConnectedState(out Desc, 0);
-        }
-
-        #endregion
-
-        #region Update System
-
-        /// <summary>
-        /// checks for an update
-        /// called on each start-up of FTPbox.
-        /// </summary>
-        private void CheckForUpdate()
-        {
-            try
-            {
-                WebClient wc = new WebClient();
-                wc.DownloadStringCompleted += (o, e) =>
-                {
-                    if (e.Cancelled || e.Error != null) return;
-
-                    var json = (Dictionary<string, string>) Newtonsoft.Json.JsonConvert.DeserializeObject(e.Result, typeof (Dictionary<string, string>));
-                    string version = json["NewVersion"];
-
-                    //  Check that the downloaded file has the correct version format, using regex.
-                    if (System.Text.RegularExpressions.Regex.IsMatch(version, @"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"))
-                    {
-                        Log.Write(l.Debug, "Current Version: {0} Installed Version: {1}", version, Application.ProductVersion);
-
-                        if (version == Application.ProductVersion) return;
-
-                        // show dialog box for  download now, learn more and remind me next time
-                        newversion nvform = new newversion() {Tag = this};
-                        newversion.newvers = json["NewVersion"];
-                        newversion.downLink = json["DownloadLink"];
-                        nvform.ShowDialog();
-                        this.Show();                
-                    }
-                };
-                // Find out what the latest version is
-                wc.DownloadStringAsync(new Uri(@"http://ftpbox.org/winversion.json"));
-            }
-            catch (Exception ex)
-            {
-                Log.Write(l.Debug, "Error with version checking");
-                Common.LogError(ex);
-            }
+            int desc;
+            return InternetGetConnectedState(out desc, 0);
         }
 
         #endregion
@@ -569,249 +733,326 @@ namespace FTPbox.Forms
             {
                 SetStartup(chkStartUp.Checked);
             }
-            catch (Exception ex) { Common.LogError(ex); }
+            catch (Exception ex)
+            {
+                Common.LogError(ex);
+            }
         }
 
         /// <summary>
-        /// run FTPbox on windows startup
-        /// <param name="enable"><c>true</c> to add it to system startup, <c>false</c> to remove it</param>
+        ///     run FTPbox on windows startup
+        ///     <param name="enable"><c>true</c> to add it to system startup, <c>false</c> to remove it</param>
         /// </summary>
-        private void SetStartup(bool enable)
+        private static void SetStartup(bool enable)
         {
             const string runKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
 
-            RegistryKey startupKey = Registry.CurrentUser.OpenSubKey(runKey);
+            var startupKey = Registry.CurrentUser.OpenSubKey(runKey);
 
             if (enable)
             {
-                if (startupKey.GetValue("FTPbox") == null)
+                if (startupKey != null && startupKey.GetValue("FTPbox") == null)
                 {
                     startupKey = Registry.CurrentUser.OpenSubKey(runKey, true);
-                    startupKey.SetValue("FTPbox", Application.ExecutablePath);
-                    startupKey.Close();
+                    if (startupKey != null)
+                    {
+                        startupKey.SetValue("FTPbox", Application.ExecutablePath);
+                        startupKey.Close();
+                    }
                 }
             }
             else
             {
                 // remove startup
                 startupKey = Registry.CurrentUser.OpenSubKey(runKey, true);
-                startupKey.DeleteValue("FTPbox", false);
-                startupKey.Close();
+                if (startupKey != null)
+                {
+                    startupKey.DeleteValue("FTPbox", false);
+                    startupKey.Close();
+                }
             }
         }
 
         /// <summary>
-        /// returns true if FTPbox is set to start on windows startup
+        ///     returns true if FTPbox is set to start on windows startup
         /// </summary>
         /// <returns></returns>
-        private bool CheckStartup()
+        private static bool CheckStartup()
         {
             const string runKey = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
 
-            RegistryKey startupKey = Registry.CurrentUser.OpenSubKey(runKey);
+            var startupKey = Registry.CurrentUser.OpenSubKey(runKey);
 
-            return startupKey.GetValue("FTPbox") != null;
+            return startupKey != null && startupKey.GetValue("FTPbox") != null;
         }
-        
+
         #endregion
 
         #region Speed Limits
 
-        private bool LimitUpSpeed()
+        private static bool LimitUpSpeed()
         {
             return Settings.General.UploadLimit > 0;
         }
 
-        private bool LimitDownSpeed()
+        private static bool LimitDownSpeed()
         {
             return Settings.General.DownloadLimit > 0;
         }
-        
-        #endregion        
+
+        #endregion
 
         #region context menus
 
         private void AddContextMenu()
         {
             Log.Write(l.Info, "Adding registry keys for context menus");
-            string reg_path = "Software\\Classes\\*\\Shell\\FTPbox";
-            RegistryKey key = Registry.CurrentUser;
-            key.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            string icon_path = string.Format("\"{0}\"", Path.Combine(Application.StartupPath, "ftpboxnew.ico"));
-            string applies_to = getAppliesTo(false);
+            var regPath = "Software\\Classes\\*\\Shell\\FTPbox";
+            var key = Registry.CurrentUser;
+            key.CreateSubKey(regPath);
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            var iconPath = string.Format("\"{0}\"", Path.Combine(Application.StartupPath, "ftpboxnew.ico"));
+            var appliesTo = GetAppliesTo(false);
             string command;
 
             //Add the parent menu
-            key.SetValue("MUIVerb", "FTPbox");
-            key.SetValue("Icon", icon_path);
-            key.SetValue("SubCommands", "");
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "FTPbox");
+                key.SetValue("Icon", iconPath);
+                key.SetValue("SubCommands", "");
 
-            //The 'Copy link' child item
-            reg_path = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Copy";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Copy HTTP link");
-            key.SetValue("AppliesTo", applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //The 'Copy link' child item
+                regPath = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Copy";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Copy HTTP link");
+                key.SetValue("AppliesTo", appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "copy");
             key.SetValue("", command);
 
             //the 'Open in browser' child item
-            reg_path = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Open";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Open file in browser");
-            key.SetValue("AppliesTo", applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+            regPath = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Open";
+            Registry.CurrentUser.CreateSubKey(regPath);
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Open file in browser");
+                key.SetValue("AppliesTo", appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "open");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            //the 'Synchronize this file' child item
-            reg_path = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Sync";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Synchronize this file");
-            key.SetValue("AppliesTo", applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //the 'Synchronize this file' child item
+                regPath = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Sync";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Synchronize this file");
+                key.SetValue("AppliesTo", appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "sync");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            //the 'Move to FTPbox folder' child item
-            reg_path = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Move";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Move to FTPbox folder");
-            key.SetValue("AppliesTo", getAppliesTo(true));
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //the 'Move to FTPbox folder' child item
+                regPath = "Software\\Classes\\*\\Shell\\FTPbox\\Shell\\Move";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Move to FTPbox folder");
+                key.SetValue("AppliesTo", GetAppliesTo(true));
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "move");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            #region same keys for the Folder menus
-            reg_path = "Software\\Classes\\Directory\\Shell\\FTPbox";
+                #region same keys for the Folder menus
+
+                regPath = "Software\\Classes\\Directory\\Shell\\FTPbox";
+            }
             key = Registry.CurrentUser;
-            key.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+            key.CreateSubKey(regPath);
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
 
             //Add the parent menu
-            key.SetValue("MUIVerb", "FTPbox");
-            key.SetValue("Icon", icon_path);
-            key.SetValue("SubCommands", "");
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "FTPbox");
+                key.SetValue("Icon", iconPath);
+                key.SetValue("SubCommands", "");
 
-            //The 'Copy link' child item
-            reg_path = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Copy";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Copy HTTP link");
-            key.SetValue("AppliesTo", applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //The 'Copy link' child item
+                regPath = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Copy";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Copy HTTP link");
+                key.SetValue("AppliesTo", appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "copy");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            //the 'Open in browser' child item
-            reg_path = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Open";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Open folder in browser");
-            key.SetValue("AppliesTo", applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //the 'Open in browser' child item
+                regPath = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Open";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Open folder in browser");
+                key.SetValue("AppliesTo", appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "open");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            //the 'Synchronize this folder' child item
-            reg_path = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Sync";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Synchronize this folder");
-            key.SetValue("AppliesTo", applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //the 'Synchronize this folder' child item
+                regPath = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Sync";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Synchronize this folder");
+                key.SetValue("AppliesTo", appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "sync");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            //the 'Move to FTPbox folder' child item
-            reg_path = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Move";
-            Registry.CurrentUser.CreateSubKey(reg_path);
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
-            key.SetValue("MUIVerb", "Move to FTPbox folder");
-            key.SetValue("AppliesTo", "NOT " + applies_to);
-            key.CreateSubKey("Command");
-            reg_path += "\\Command";
-            key = Registry.CurrentUser.OpenSubKey(reg_path, true);
+                //the 'Move to FTPbox folder' child item
+                regPath = "Software\\Classes\\Directory\\Shell\\FTPbox\\Shell\\Move";
+                Registry.CurrentUser.CreateSubKey(regPath);
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
+            if (key != null)
+            {
+                key.SetValue("MUIVerb", "Move to FTPbox folder");
+                key.SetValue("AppliesTo", "NOT " + appliesTo);
+                key.CreateSubKey("Command");
+                regPath += "\\Command";
+            }
+            key = Registry.CurrentUser.OpenSubKey(regPath, true);
             command = string.Format("\"{0}\" \"%1\" \"{1}\"", Application.ExecutablePath, "move");
-            key.SetValue("", command);
+            if (key != null)
+            {
+                key.SetValue("", command);
 
-            #endregion
+                #endregion
 
-            key.Close();
+                key.Close();
+            }
         }
 
         /// <summary>
-        /// Remove the FTPbox context menu (delete the registry files). 
-        /// Called when application is exiting.
+        ///     Remove the FTPbox context menu (delete the registry files).
+        ///     Called when application is exiting.
         /// </summary>
-        private void RemoveFTPboxMenu()
+        private static void RemoveFTPboxMenu()
         {
-            RegistryKey key = Registry.CurrentUser.OpenSubKey("Software\\Classes\\*\\Shell\\", true);            
-            key.DeleteSubKeyTree("FTPbox", false);
-            key.Close();
+            var key = Registry.CurrentUser.OpenSubKey("Software\\Classes\\*\\Shell\\", true);
+            if (key != null)
+            {
+                key.DeleteSubKeyTree("FTPbox", false);
+                key.Close();
+            }
 
             key = Registry.CurrentUser.OpenSubKey("Software\\Classes\\Directory\\Shell\\", true);
-            key.DeleteSubKeyTree("FTPbox", false);
-            key.Close();
+            if (key != null)
+            {
+                key.DeleteSubKeyTree("FTPbox", false);
+                key.Close();
+            }
         }
 
         /// <summary>
-        /// Gets the value of the AppliesTo String Value that will be put to registry and determine on which files' right-click menus each FTPbox menu item will show.
-        /// If the local path is inside a library folder, it has to check for another path (short_path), because System.ItemFolderPathDisplay will, for example, return 
-        /// Documents\FTPbox instead of C:\Users\Username\Documents\FTPbox
+        ///     Gets the value of the AppliesTo String Value that will be put to registry and determine on which files' right-click
+        ///     menus each FTPbox menu item will show.
+        ///     If the local path is inside a library folder, it has to check for another path (short_path), because
+        ///     System.ItemFolderPathDisplay will, for example, return
+        ///     Documents\FTPbox instead of C:\Users\Username\Documents\FTPbox
         /// </summary>
-        /// <param name="isForMoveItem">If the AppliesTo value is for the Move-to-FTPbox item, it adds 'NOT' to make sure it shows anywhere but in the local syncing folder.</param>
+        /// <param name="isForMoveItem">
+        ///     If the AppliesTo value is for the Move-to-FTPbox item, it adds 'NOT' to make sure it shows
+        ///     anywhere but in the local syncing folder.
+        /// </param>
         /// <returns></returns>
-        private string getAppliesTo(bool isForMoveItem)
+        private static string GetAppliesTo(bool isForMoveItem)
         {
-            string path = Program.Account.Paths.Local;
-            string applies_to = (isForMoveItem) ? string.Format("NOT System.ItemFolderPathDisplay:~< \"{0}\"", path) : string.Format("System.ItemFolderPathDisplay:~< \"{0}\"", path);
-            string short_path = null;
-            var Libraries = new[] { Environment.SpecialFolder.MyDocuments, Environment.SpecialFolder.MyMusic, Environment.SpecialFolder.MyPictures, Environment.SpecialFolder.MyVideos };
-            string userpath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + @"\";
+            var path = Program.Account.Paths.Local;
+            var appliesTo = (isForMoveItem)
+                ? string.Format("NOT System.ItemFolderPathDisplay:~< \"{0}\"", path)
+                : string.Format("System.ItemFolderPathDisplay:~< \"{0}\"", path);
+            string shortPath = null;
+            var libraries = new[]
+            {Environment.SpecialFolder.MyDocuments, Environment.SpecialFolder.MyMusic, Environment.SpecialFolder.MyPictures, Environment.SpecialFolder.MyVideos};
+            var userpath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + @"\";
 
             if (path.StartsWith(userpath))
-                foreach (Environment.SpecialFolder s in Libraries)            
+                foreach (var s in libraries)
                     if (path.StartsWith(Environment.GetFolderPath(s)))
                         if (s != Environment.SpecialFolder.UserProfile) //TODO: is this ok?
-                            short_path = path.Substring(userpath.Length);            
+                            shortPath = path.Substring(userpath.Length);
 
-            if (short_path == null) return applies_to;
+            if (shortPath == null) return appliesTo;
 
-            applies_to += (isForMoveItem) ? string.Format(" AND NOT System.ItemFolderPathDisplay: \"*{0}*\"", short_path) : string.Format(" OR System.ItemFolderPathDisplay: \"*{0}*\"", short_path);
+            appliesTo += (isForMoveItem)
+                ? string.Format(" AND NOT System.ItemFolderPathDisplay: \"*{0}*\"", shortPath)
+                : string.Format(" OR System.ItemFolderPathDisplay: \"*{0}*\"", shortPath);
 
-            return applies_to;
+            return appliesTo;
         }
 
         private void RunServer()
         {
-            var _tServer = new Thread(RunServerThread);
-            _tServer.SetApartmentState(ApartmentState.STA);
-            _tServer.Start();            
+            var tServer = new Thread(RunServerThread);
+            tServer.SetApartmentState(ApartmentState.STA);
+            tServer.Start();
         }
 
         private void RunServerThread()
         {
-            int i = 1;
+            var i = 1;
             Log.Write(l.Client, "Started the named-pipe server, waiting for clients (if any)");
 
             var server = new Thread(ServerThread);
@@ -836,24 +1077,25 @@ namespace FTPbox.Forms
         public void ServerThread()
         {
             var pipeServer = new NamedPipeServerStream("FTPbox Server", PipeDirection.InOut, 5);
-            int threadID = Thread.CurrentThread.ManagedThreadId;
+            var threadID = Thread.CurrentThread.ManagedThreadId;
 
             pipeServer.WaitForConnection();
-            
+
             Log.Write(l.Client, "Client connected, id: {0}", threadID);
 
             try
             {
-                StreamString ss = new StreamString(pipeServer);
+                var ss = new StreamString(pipeServer);
 
                 ss.WriteString("ftpbox");
-                string args = ss.ReadString();
+                var args = ss.ReadString();
 
-                ReadMessageSent fReader = new ReadMessageSent(ss, "All done!");
+                var fReader = new ReadMessageSent(ss, "All done!");
 
-                Log.Write(l.Client, "Reading file: \n {0} \non thread [{1}] as user {2}.", args, threadID, pipeServer.GetImpersonationUserName());
+                Log.Write(l.Client, "Reading file: \n {0} \non thread [{1}] as user {2}.", args, threadID,
+                    pipeServer.GetImpersonationUserName());
 
-                CheckClientArgs( ReadCombinedParameters(args).ToArray() );
+                CheckClientArgs(ReadCombinedParameters(args).ToArray());
 
                 pipeServer.RunAsClient(fReader.Start);
             }
@@ -864,19 +1106,19 @@ namespace FTPbox.Forms
             pipeServer.Close();
         }
 
-        private List<string> ReadCombinedParameters(string args)
+        private static List<string> ReadCombinedParameters(string args)
         {
-            List<string> r = new List<string>(args.Split('"'));
-            while(r.Contains(""))
+            var r = new List<string>(args.Split('"'));
+            while (r.Contains(""))
                 r.Remove("");
 
             return r;
         }
 
-        private void CheckClientArgs(string[] args)
+        private void CheckClientArgs(IEnumerable<string> args)
         {
             var list = new List<string>(args);
-            string param = list[0];
+            var param = list[0];
             list.RemoveAt(0);
 
             switch (param)
@@ -897,26 +1139,28 @@ namespace FTPbox.Forms
         }
 
         private DateTime dtLastContextAction = DateTime.Now;
+
         /// <summary>
-        /// Called when 'Copy HTTP link' is clicked from the context menus
+        ///     Called when 'Copy HTTP link' is clicked from the context menus
         /// </summary>
         /// <param name="args"></param>
         private void CopyArgLinks(string[] args)
         {
             string c = null;
-            int i = 0;
-            foreach (string s in args)
+            var i = 0;
+            foreach (var s in args)
             {
                 if (!s.StartsWith(Program.Account.Paths.Local))
                 {
-                    MessageBox.Show("You cannot use this for files that are not inside the FTPbox folder.", "FTPbox - Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show("You cannot use this for files that are not inside the FTPbox folder.",
+                        "FTPbox - Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     continue;
                 }
 
                 i++;
                 //if (File.Exists(s))
                 c += Program.Account.GetHttpLink(s);
-                if (i<args.Count())
+                if (i < args.Count())
                     c += Environment.NewLine;
             }
 
@@ -926,7 +1170,7 @@ namespace FTPbox.Forms
             {
                 if ((DateTime.Now - dtLastContextAction).TotalSeconds < 2)
                     Clipboard.SetText(Clipboard.GetText() + Environment.NewLine + c);
-                else                    
+                else
                     Clipboard.SetText(c);
                 //SetTray(null, new FTPboxLib.TrayTextNotificationArgs { MessageType = FTPboxLib.MessageType.LinkCopied });
             }
@@ -938,25 +1182,26 @@ namespace FTPbox.Forms
         }
 
         /// <summary>
-        /// Called when 'Synchronize this file/folder' is clicked from the context menus
+        ///     Called when 'Synchronize this file/folder' is clicked from the context menus
         /// </summary>
         /// <param name="args"></param>
-        private void SyncArgItems(string[] args)
+        private static void SyncArgItems(IEnumerable<string> args)
         {
-            foreach (string s in args)
+            foreach (var s in args)
             {
                 Log.Write(l.Info, "Syncing local item: {0}", s);
                 if (!s.StartsWith(Program.Account.Paths.Local))
                 {
-                    MessageBox.Show("You cannot use this for files that are not inside the FTPbox folder.", "FTPbox - Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show("You cannot use this for files that are not inside the FTPbox folder.",
+                        "FTPbox - Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     continue;
                 }
                 var cpath = Program.Account.GetCommonPath(s, true);
-                bool exists = Program.Account.Client.Exists(cpath);
+                var exists = Program.Account.Client.Exists(cpath);
 
                 if (Common.PathIsFile(s) && File.Exists(s))
                 {
-                    Program.Account.SyncQueue.Add(new SyncQueueItem (Program.Account)
+                    Program.Account.SyncQueue.Add(new SyncQueueItem(Program.Account)
                     {
                         Item = new ClientItem
                         {
@@ -973,7 +1218,7 @@ namespace FTPbox.Forms
                 else if (!Common.PathIsFile(s) && Directory.Exists(s))
                 {
                     var di = new DirectoryInfo(s);
-                    Program.Account.SyncQueue.Add(new SyncQueueItem (Program.Account)
+                    Program.Account.SyncQueue.Add(new SyncQueueItem(Program.Account)
                     {
                         Item = new ClientItem
                         {
@@ -992,20 +1237,21 @@ namespace FTPbox.Forms
         }
 
         /// <summary>
-        /// Called when 'Open in browser' is clicked from the context menus
+        ///     Called when 'Open in browser' is clicked from the context menus
         /// </summary>
         /// <param name="args"></param>
-        private void OpenArgItemsInBrowser(string[] args)
+        private void OpenArgItemsInBrowser(IEnumerable<string> args)
         {
-            foreach (string s in args)
+            foreach (var s in args)
             {
                 if (!s.StartsWith(Program.Account.Paths.Local))
                 {
-                    MessageBox.Show("You cannot use this for files that are not inside the FTPbox folder.", "FTPbox - Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MessageBox.Show("You cannot use this for files that are not inside the FTPbox folder.",
+                        "FTPbox - Invalid file", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     continue;
                 }
 
-                string link = Program.Account.GetHttpLink(s);
+                var link = Program.Account.GetHttpLink(s);
                 try
                 {
                     Process.Start(link);
@@ -1015,35 +1261,35 @@ namespace FTPbox.Forms
                     Common.LogError(e);
                 }
             }
-            
+
             dtLastContextAction = DateTime.Now;
         }
 
         /// <summary>
-        /// Called when 'Move to FTPbox folder' is clicked from the context menus
+        ///     Called when 'Move to FTPbox folder' is clicked from the context menus
         /// </summary>
         /// <param name="args"></param>
-        private void MoveArgItems(string[] args)
+        private static void MoveArgItems(IEnumerable<string> args)
         {
-            foreach (string s in args)
+            foreach (var s in args)
             {
                 if (!s.StartsWith(Program.Account.Paths.Local))
                 {
                     if (File.Exists(s))
                     {
-                        FileInfo fi = new FileInfo(s);
+                        var fi = new FileInfo(s);
                         File.Copy(s, Path.Combine(Program.Account.Paths.Local, fi.Name));
                     }
                     else if (Directory.Exists(s))
                     {
-                        foreach (string dir in Directory.GetDirectories(s, "*", SearchOption.AllDirectories))
+                        foreach (var dir in Directory.GetDirectories(s, "*", SearchOption.AllDirectories))
                         {
-                            string name = dir.Substring(s.Length);
+                            var name = dir.Substring(s.Length);
                             Directory.CreateDirectory(Path.Combine(Program.Account.Paths.Local, name));
                         }
-                        foreach (string file in Directory.GetFiles(s, "*", SearchOption.AllDirectories))
+                        foreach (var file in Directory.GetFiles(s, "*", SearchOption.AllDirectories))
                         {
-                            string name = file.Substring(s.Length);
+                            var name = file.Substring(s.Length);
                             File.Copy(file, Path.Combine(Program.Account.Paths.Local, name));
                         }
                     }
@@ -1076,7 +1322,7 @@ namespace FTPbox.Forms
         private void rOpenLocal_CheckedChanged(object sender, EventArgs e)
         {
             if (rOpenLocal.Checked)
-            {                
+            {
                 Settings.General.TrayAction = TrayAction.OpenLocalFile;
                 Settings.SaveGeneral();
             }
@@ -1090,21 +1336,21 @@ namespace FTPbox.Forms
 
         private void chkWebInt_CheckedChanged(object sender, EventArgs e)
         {
-            if (!Program.Account.Client.isConnected) return; 
-            
-            if (!changedfromcheck)
+            if (!Program.Account.Client.isConnected) return;
+
+            if (!_changedfromcheck)
             {
                 if (chkWebInt.Checked)
                     Program.Account.WebInterface.UpdatePending = true;
                 else
                     Program.Account.WebInterface.DeletePending = true;
-                
+
                 chkWebInt.Enabled = false;
 
                 if (!Program.Account.SyncQueue.Running)
                     Program.Account.WebInterface.Update();
             }
-            changedfromcheck = false;
+            _changedfromcheck = false;
         }
 
         private void labViewInBrowser_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -1122,11 +1368,10 @@ namespace FTPbox.Forms
 
         private void bBrowseLogs_Click(object sender, EventArgs e)
         {
-            string logFile = Path.Combine(Common.AppdataFolder, "Debug.html");
+            var logFile = Path.Combine(Common.AppdataFolder, "Debug.html");
 
             if (File.Exists(logFile))
                 Process.Start("explorer.exe", logFile);
-
         }
 
         private void chkShellMenus_CheckedChanged(object sender, EventArgs e)
@@ -1150,9 +1395,10 @@ namespace FTPbox.Forms
 
         private void bRemoveAccount_Click(object sender, EventArgs e)
         {
-            string msg = string.Format("Are you sure you want to delete profile: {0}?",
-                   Settings.ProfileTitles[Settings.General.DefaultProfile]);
-            if (MessageBox.Show(msg, "Confirm Account Deletion", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            var msg = string.Format("Are you sure you want to delete profile: {0}?",
+                Settings.ProfileTitles[Settings.General.DefaultProfile]);
+            if (MessageBox.Show(msg, "Confirm Account Deletion", MessageBoxButtons.YesNo, MessageBoxIcon.Question) ==
+                DialogResult.Yes)
             {
                 Settings.RemoveCurrentProfile();
 
@@ -1160,7 +1406,7 @@ namespace FTPbox.Forms
                 Process.Start(Application.ExecutablePath);
                 KillTheProcess();
             }
-        }        
+        }
 
         private void bAddAccount_Click(object sender, EventArgs e)
         {
@@ -1231,7 +1477,7 @@ namespace FTPbox.Forms
 
         private void bConfigureSelectiveSync_Click(object sender, EventArgs e)
         {
-            fSelective.ShowDialog();
+            _fSelective.ShowDialog();
         }
 
         private void bConfigureExtensions_Click(object sender, EventArgs e)
@@ -1256,18 +1502,22 @@ namespace FTPbox.Forms
         {
             dtpLastModTime.Enabled = cIgnoreOldFiles.Checked;
             Program.Account.IgnoreList.IgnoreOldFiles = cIgnoreOldFiles.Checked;
-            Program.Account.IgnoreList.LastModifiedMinimum = (cIgnoreOldFiles.Checked) ? dtpLastModTime.Value : DateTime.MinValue;
+            Program.Account.IgnoreList.LastModifiedMinimum = (cIgnoreOldFiles.Checked)
+                ? dtpLastModTime.Value
+                : DateTime.MinValue;
             Program.Account.IgnoreList.Save();
         }
 
         private void dtpLastModTime_ValueChanged(object sender, EventArgs e)
         {
             Program.Account.IgnoreList.IgnoreOldFiles = cIgnoreOldFiles.Checked;
-            Program.Account.IgnoreList.LastModifiedMinimum = (cIgnoreOldFiles.Checked) ? dtpLastModTime.Value : DateTime.MinValue;
+            Program.Account.IgnoreList.LastModifiedMinimum = (cIgnoreOldFiles.Checked)
+                ? dtpLastModTime.Value
+                : DateTime.MinValue;
             Program.Account.IgnoreList.Save();
         }
 
-        #endregion 
+        #endregion
 
         #region Bandwidth Tab - Event Handlers
 
@@ -1320,7 +1570,9 @@ namespace FTPbox.Forms
                 Settings.General.DownloadLimit = Convert.ToInt32(nDownLimit.Value);
                 Settings.SaveGeneral();
             }
-            catch { }
+            catch
+            {
+            }
         }
 
         private void nUpLimit_ValueChanged(object sender, EventArgs e)
@@ -1330,7 +1582,9 @@ namespace FTPbox.Forms
                 Settings.General.UploadLimit = Convert.ToInt32(nUpLimit.Value);
                 Settings.SaveGeneral();
             }
-            catch { }
+            catch
+            {
+            }
         }
 
         #endregion
@@ -1374,15 +1628,15 @@ namespace FTPbox.Forms
 
         private void tray_MouseClick(object sender, MouseEventArgs e)
         {
-            if (!fTrayForm.Visible && e.Button == MouseButtons.Left)
+            if (!_fTrayForm.Visible && e.Button == MouseButtons.Left)
             {
                 var mouse = MousePosition;
                 // Show the tray form
-                fTrayForm.Show();
+                _fTrayForm.Show();
                 // Make sure tray form gets focus
-                fTrayForm.Activate();
+                _fTrayForm.Activate();
                 // Move the form to the correct position
-                fTrayForm.PositionProperly(mouse);
+                _fTrayForm.PositionProperly(mouse);
             }
         }
 
@@ -1393,13 +1647,14 @@ namespace FTPbox.Forms
             StartRemoteSync(".");
         }
 
-        public bool ExitedFromTray = false;
+        public bool ExitedFromTray;
+
         private void fMain_FormClosing(object sender, FormClosingEventArgs e)
         {
             if (!ExitedFromTray && e.CloseReason != CloseReason.WindowsShutDown)
             {
                 e.Cancel = true;
-                this.Hide();
+                Hide();
             }
         }
 
@@ -1410,23 +1665,23 @@ namespace FTPbox.Forms
 
         private void optionsToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            this.Show();
-            this.WindowState = FormWindowState.Normal;
-            this.BringToFront();
+            Show();
+            WindowState = FormWindowState.Normal;
+            BringToFront();
         }
 
         private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            this.Show();
+            Show();
             tabControl1.SelectedTab = tabAbout;
         }
 
         private void tray_BalloonTipClicked(object sender, EventArgs e)
         {
-            if (string.IsNullOrWhiteSpace(link)) return;
+            if (string.IsNullOrWhiteSpace(Link)) return;
 
-            if (link.EndsWith("webint"))
-                Process.Start(link);
+            if (Link.EndsWith("webint"))
+                Process.Start(Link);
             else
             {
                 if ((MouseButtons & MouseButtons.Right) != MouseButtons.Right)
@@ -1452,7 +1707,7 @@ namespace FTPbox.Forms
                         {
                             //Gotta catch 'em all 
                         }
-                        SetTray(null, new TrayTextNotificationArgs { MessageType = MessageType.LinkCopied });
+                        SetTray(null, new TrayTextNotificationArgs {MessageType = MessageType.LinkCopied});
                     }
                     else
                     {
@@ -1469,148 +1724,6 @@ namespace FTPbox.Forms
             }
         }
 
-        #endregion                
-
-        private void bTranslate_Click(object sender, EventArgs e)
-        {
-            ftranslate.ShowDialog();
-        }
-
-        public void SetTray(object o, TrayTextNotificationArgs e)
-        {
-            try
-            {
-                // Save latest tray status
-                _lastTrayStatus = e;
-
-                switch (e.MessageType)
-                {
-                    case MessageType.Connecting:
-                    case MessageType.Reconnecting:
-                    case MessageType.Syncing:
-                        tray.Icon = Properties.Resources.syncing;
-                        tray.Text = Common.Languages[e.MessageType];
-                        break;
-                    case MessageType.Uploading:
-                    case MessageType.Downloading:
-                        tray.Icon = Properties.Resources.syncing;
-                        tray.Text = Common.Languages[MessageType.Syncing];
-                        break;
-                    case MessageType.AllSynced:
-                    case MessageType.Ready:
-                        tray.Icon = Properties.Resources.AS;
-                        tray.Text = Common.Languages[e.MessageType];
-                        break;
-                    case MessageType.Offline:
-                    case MessageType.Disconnected:
-                        tray.Icon = Properties.Resources.offline1;
-                        tray.Text = Common.Languages[e.MessageType];
-                        break;
-                    case MessageType.Listing:
-                        tray.Icon = Properties.Resources.AS;
-                        tray.Text = (Program.Account.Account.SyncMethod == SyncMethod.Automatic) ? Common.Languages[MessageType.AllSynced] : Common.Languages[MessageType.Listing];
-                        break;
-                    case MessageType.Nothing:
-                        tray.Icon = Properties.Resources.ftpboxnew;
-                        tray.Text = Common.Languages[e.MessageType];
-                        break;
-                }
-            }
-            catch (Exception ex)
-            {
-                Common.LogError(ex);
-            }
-        }
-
-        /// <summary>
-        /// Starts the remote-to-local syncing on the root folder.
-        /// Called from the timer, when remote syncing is automatic.
-        /// </summary>
-        /// <param name="state"></param>
-        public void StartRemoteSync(object state)
-        {
-            if (Program.Account.Account.SyncMethod == SyncMethod.Automatic) SyncToolStripMenuItem.Enabled = false;
-            Log.Write(l.Debug, "Starting remote sync...");
-            Program.Account.SyncQueue.Add(new SyncQueueItem (Program.Account)
-            {
-                Item = new ClientItem
-                {
-                    FullPath = (string)state,
-                    Name = (string)state,
-                    Type = ClientItemType.Folder,
-                    Size = 0x0,
-                    LastWriteTime = DateTime.Now
-                },
-                ActionType = ChangeAction.changed,
-                SyncTo = SyncTo.Local,
-                SkipNotification = true
-            });
-        }
-
-        /// <summary>
-        /// Display a messagebox with the certificate details, ask user to approve/decline it.
-        /// </summary>
-        public static void CheckCertificate(object sender, ValidateCertificateEventArgs n)
-        {
-            var msg = string.Empty;
-            // Add certificate info
-            if (Program.Account.Account.Protocol == FtpProtocol.SFTP)
-                msg += string.Format("{0,-8}\t {1}\n{2,-8}\t {3}\n", "Key:", n.Key, "Key Size:", n.KeySize);
-            else
-                msg += string.Format("{0,-25}\t {1}\n{2,-25}\t {3}\n{4,-25}\t {5}\n{6,-25}\t {7}\n\n",
-                    "Valid from:", n.ValidFrom, "Valid to:", n.ValidTo, "Serial number:", n.SerialNumber, "Algorithm:", n.Algorithm);
-
-            msg += string.Format("Fingerprint: {0}\n\n", n.Fingerprint);
-            msg += "Trust this certificate and continue?";
-
-            // Do we trust the server's certificate?
-            bool certificate_trusted = MessageBox.Show(msg, "Do you trust this certificate?", MessageBoxButtons.YesNo, MessageBoxIcon.Information) == DialogResult.Yes;
-            n.IsTrusted = certificate_trusted;
-
-            if (certificate_trusted)
-            {
-                Settings.TrustedCertificates.Add(n.Fingerprint);
-                Settings.SaveCertificates();
-            }
-        }
-
-        private void fMain_RightToLeftLayoutChanged(object sender, EventArgs e)
-        {
-            RightToLeft = RightToLeftLayout ? RightToLeft.Yes : RightToLeft.No;
-            // Inherit manually
-            tabControl1.RightToLeftLayout = RightToLeftLayout;
-            trayMenu.RightToLeft = RightToLeftLayout ? RightToLeft.Yes : RightToLeft.No;
-
-            // Relocate controls where necessary
-            cLanguages.Location = RightToLeftLayout ? new Point(267, 19) : new Point(9, 19);
-            bTranslate.Location = RightToLeftLayout ? new Point(172, 17) : new Point(191, 17);
-            bBrowseLogs.Location = RightToLeftLayout ? new Point(172, 61) : new Point(191, 61); 
-
-            bAddAccount.Location = new Point(RightToLeftLayout ? 14 : 299, 10);
-            bRemoveAccount.Location = new Point(RightToLeftLayout ? 95 : 380, 10);
-            cProfiles.Location = new Point(RightToLeftLayout ? 170 : 8, 11);
-            bConfigureAccount.Location = new Point(RightToLeftLayout ? 6 : 325, 16);
-
-            bConfigureSelectiveSync.Location = new Point(RightToLeftLayout ? 6 : 325, 19);
-            bConfigureExtensions.Location = new Point(RightToLeftLayout ? 6 : 325, 48);
-
-            //bRefresh.Location = new Point(RightToLeftLayout ? 9 : 352, 19);
-            nSyncFrequency.Location = RightToLeftLayout ? new Point(344, 89) : new Point(35, 89);
-            nDownLimit.Location = RightToLeftLayout ? new Point(344, 45) : new Point(35, 45);
-            nUpLimit.Location = RightToLeftLayout ? new Point(344, 100) : new Point(35, 100);
-
-            lVersion.Location = RightToLeftLayout ? new Point(100, 21) : new Point(272, 21);
-            linkLabel3.Location = RightToLeftLayout ? new Point(100, 44) : new Point(272, 44);
-            linkLabel4.Location = RightToLeftLayout ? new Point(100, 67) : new Point(272, 67);
-            label21.Location = RightToLeftLayout ? new Point(100, 90) : new Point(272, 90);
-            labSupportMail.Location = RightToLeftLayout ? new Point(100, 113) : new Point(272, 113);
-            label19.Location = RightToLeftLayout ? new Point(100, 136) : new Point(272, 136);
-
-            labCurVersion.Location = RightToLeftLayout ? new Point(272, 21) : new Point(100, 21);
-            labTeam.Location = RightToLeftLayout ? new Point(272, 44) : new Point(100, 44);
-            labSite.Location = RightToLeftLayout ? new Point(272, 21) : new Point(100, 71);
-            labContact.Location = RightToLeftLayout ? new Point(272, 90) : new Point(100, 90);
-            labLangUsed.Location = RightToLeftLayout ? new Point(272, 136) : new Point(100, 136);
-        }
+        #endregion
     }
 }

--- a/Windows/FTPbox/Forms/fTrayForm.cs
+++ b/Windows/FTPbox/Forms/fTrayForm.cs
@@ -10,44 +10,48 @@ namespace FTPbox.Forms
 {
     public partial class fTrayForm : Form
     {
+        /// <summary>
+        ///     This item will be added to the recent list when a file transfer is in progress
+        /// </summary>
+        private readonly trayFormListItem _transferItem = new trayFormListItem();
+
+        /// <summary>
+        ///     the latest status used to set the status label
+        /// </summary>
+        private TrayTextNotificationArgs _lastStatus = new TrayTextNotificationArgs
+        {
+            AssossiatedFile = null,
+            MessageType = MessageType.AllSynced
+        };
+
         public fTrayForm()
         {
             InitializeComponent();
 
             Notifications.TrayTextNotification += (o, n) =>
-                {
-                    if (this.IsHandleCreated)
-                        this.Invoke(new MethodInvoker(() => SetStatusLabel(o, n)));
-                    else
-                        _lastStatus = n;
-                };
+            {
+                if (IsHandleCreated)
+                    Invoke(new MethodInvoker(() => SetStatusLabel(o, n)));
+                else
+                    _lastStatus = n;
+            };
             // Make status label same color as the icons
             lCurrentStatus.ForeColor = Color.FromArgb(105, 105, 105);
         }
 
-        /// <summary>
-        /// the latest status used to set the status label
-        /// </summary>
-        private TrayTextNotificationArgs _lastStatus = new TrayTextNotificationArgs { AssossiatedFile = null, MessageType = MessageType.AllSynced };
-
-        /// <summary>
-        /// This item will be added to the recent list when a file transfer is in progress
-        /// </summary>
-        private readonly trayFormListItem _transferItem = new trayFormListItem();
-
         private void fTrayForm_Load(object sender, EventArgs e)
         {
             // Make sure the border doesn't appear
-            this.Text = String.Empty;
+            Text = string.Empty;
 
-            Notifications.RecentListChanged += (o, n) => this.Invoke(new MethodInvoker(LoadRecent));
+            Notifications.RecentListChanged += (o, n) => Invoke(new MethodInvoker(LoadRecent));
 
             Program.Account.Client.TransferProgress += (o, n) =>
             {
                 // Only when Downloading/Uploading.
                 if (string.IsNullOrWhiteSpace(_lastStatus.AssossiatedFile)) return;
                 // Update item in recent list
-                this.Invoke(new MethodInvoker(() =>
+                Invoke(new MethodInvoker(() =>
                 {
                     // Get status progress for the transfer
                     var progress = string.Format("{0,3}% - {1}", n.Progress, n.Rate);
@@ -61,7 +65,7 @@ namespace FTPbox.Forms
         }
 
         /// <summary>
-        /// Load the recent items list
+        ///     Load the recent items list
         /// </summary>
         private void LoadRecent()
         {
@@ -69,25 +73,25 @@ namespace FTPbox.Forms
             // Update the Recent List
             fRecentList.Controls.Clear();
             list.ForEach(f =>
+            {
+                var fullPath = Path.GetFullPath(Path.Combine(Program.Account.Paths.Local, f.CommonPath));
+                var t = new trayFormListItem
                 {
-                    var fullPath = Path.GetFullPath(Path.Combine(Program.Account.Paths.Local, f.CommonPath));
-                    var t = new trayFormListItem
-                        {
-                            FileNameLabel = Common._name(f.CommonPath),
-                            FileStatusLabel = Common.Languages[UiControl.Modified] + " " + f.LatestChangeTime().FormatDate()
-                        };
-                    // Open the file in explorer.exe on click
-                    t.Click += (sender, args) => Process.Start("explorer.exe", @"/select, " + fullPath);
-                    fRecentList.Controls.Add(t);
-                });
+                    FileNameLabel = Common._name(f.CommonPath),
+                    FileStatusLabel = Common.Languages[UiControl.Modified] + " " + f.LatestChangeTime().FormatDate()
+                };
+                // Open the file in explorer.exe on click
+                t.Click += (sender, args) => Process.Start("explorer.exe", @"/select, " + fullPath);
+                fRecentList.Controls.Add(t);
+            });
             if (list.Count == 0)
             {
                 // If recent list is empty, just add a single 'Not Available' item
                 fRecentList.Controls.Add(new trayFormListItem
-                    {
-                        FileNameLabel = Common.Languages[MessageType.NotAvailable],
-                        FileStatusLabel = string.Empty
-                    });
+                {
+                    FileNameLabel = Common.Languages[MessageType.NotAvailable],
+                    FileStatusLabel = string.Empty
+                });
             }
         }
 
@@ -120,8 +124,8 @@ namespace FTPbox.Forms
                         break;
                     case MessageType.Listing:
                         lCurrentStatus.Text = (Program.Account.Account.SyncMethod == SyncMethod.Automatic)
-                                        ? Common.Languages[MessageType.AllSynced]
-                                        : Common.Languages[MessageType.Listing];
+                            ? Common.Languages[MessageType.AllSynced]
+                            : Common.Languages[MessageType.Listing];
                         break;
                     default:
                         lCurrentStatus.Text = Common.Languages[e.MessageType];
@@ -139,16 +143,16 @@ namespace FTPbox.Forms
 
         private void fTrayForm_Leave(object sender, EventArgs e)
         {
-            this.Hide();
+            Hide();
         }
 
         private void fTrayForm_Deactivate(object sender, EventArgs e)
         {
-            this.Hide();
+            Hide();
         }
 
         /// <summary>
-        /// Positions the form according to the location of the Windows taskbar and our tray icon
+        ///     Positions the form according to the location of the Windows taskbar and our tray icon
         /// </summary>
         /// <param name="MousePosition">the point the user clicked at when opening the form</param>
         public void PositionProperly(Point MousePosition)
@@ -156,44 +160,44 @@ namespace FTPbox.Forms
             // Get the taskbar location and type
             Win32.AppBarLocation taskbarType;
             var taskbarRectangle = Win32.GetTaskbar(out taskbarType);
-            
-            int x = 0;
-            int y = 0;
-            
+
+            var x = 0;
+            var y = 0;
+
             // Calculate where the form should be placed
             if (taskbarType == Win32.AppBarLocation.Bottom)
             {
-                x = MousePosition.X - this.Width / 2;
-                y = taskbarRectangle.Y - this.Height - 10;
+                x = MousePosition.X - Width/2;
+                y = taskbarRectangle.Y - Height - 10;
             }
             else if (taskbarType == Win32.AppBarLocation.Top)
             {
-                x = MousePosition.X - this.Width / 2;
+                x = MousePosition.X - Width/2;
                 y = taskbarRectangle.Height + 10;
             }
             else if (taskbarType == Win32.AppBarLocation.Left)
             {
                 x = taskbarRectangle.X + taskbarRectangle.Width + 10;
-                y = MousePosition.Y - this.Height / 2;
+                y = MousePosition.Y - Height/2;
             }
             else if (taskbarType == Win32.AppBarLocation.Right)
             {
-                x = taskbarRectangle.X - this.Width - 10;
-                y = MousePosition.Y - this.Height / 2;
+                x = taskbarRectangle.X - Width - 10;
+                y = MousePosition.Y - Height/2;
             }
             // Make sure the form does not get outside the screen bounds
             if (taskbarType == Win32.AppBarLocation.Bottom || taskbarType == Win32.AppBarLocation.Top)
             {
-                if (x + this.Width > taskbarRectangle.Right - 10)
-                    x = taskbarRectangle.Right - 10 - this.Width;
+                if (x + Width > taskbarRectangle.Right - 10)
+                    x = taskbarRectangle.Right - 10 - Width;
             }
             else
             {
-                if (y + this.Height > taskbarRectangle.Bottom - 10)
-                    y = taskbarRectangle.Bottom - 10 - this.Height;
+                if (y + Height > taskbarRectangle.Bottom - 10)
+                    y = taskbarRectangle.Bottom - 10 - Height;
             }
             // Set the location
-            this.Location = new Point(x, y);
+            Location = new Point(x, y);
         }
 
         private void pLocalFolder_Click(object sender, EventArgs e)
@@ -203,20 +207,20 @@ namespace FTPbox.Forms
 
         private void pSettings_Click(object sender, EventArgs e)
         {
-            ((fMain)Tag).Show();
-            ((fMain)Tag).Activate();
+            ((fMain) Tag).Show();
+            ((fMain) Tag).Activate();
         }
 
         public void Set_Language()
         {
-            if (!this.IsHandleCreated) return;
+            if (!IsHandleCreated) return;
 
-            this.Invoke(new MethodInvoker(() =>
-                {
-                    // Set the status label and load the recent files
-                    SetStatusLabel(null, _lastStatus);
-                    LoadRecent();
-                }));
+            Invoke(new MethodInvoker(() =>
+            {
+                // Set the status label and load the recent files
+                SetStatusLabel(null, _lastStatus);
+                LoadRecent();
+            }));
         }
     }
 }

--- a/Windows/FTPbox/Forms/newversion.cs
+++ b/Windows/FTPbox/Forms/newversion.cs
@@ -21,11 +21,11 @@ using FTPboxLib;
 namespace FTPbox
 {
     public partial class newversion : Form
-    {        
-        public static string newvers;
-        public static string downLink;
+    {
+        public static string Newvers;
+        public static string DownLink;
 
-        public newversion ()
+        public newversion()
         {
             InitializeComponent();
         }
@@ -33,29 +33,34 @@ namespace FTPbox
         private void newversion_Load(object sender, EventArgs e)
         {
             label3.Text = Application.ProductVersion.Substring(0, 5);
-            label5.Text = newvers.Substring(0, 5);
-            Set_Language(Settings.General.Language);          
+            label5.Text = Newvers.Substring(0, 5);
+            Set_Language(Settings.General.Language);
         }
 
         private void bDownload_Click(object sender, EventArgs e)
         {
             try
             {
-                string pathtoupdater = Application.StartupPath + @"\FTPbox Updater.exe";
+                var pathtoupdater = Application.StartupPath + @"\FTPbox Updater.exe";
 
                 while (!File.Exists(pathtoupdater))
                 {
-                    DialogResult dr = MessageBox.Show("The file updater.exe is missing from the folder. Please put it back there or reinstall before updating.", "FTPbox - Missing File", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
+                    var dr =
+                        MessageBox.Show(
+                            "The file updater.exe is missing from the folder. Please put it back there or reinstall before updating.",
+                            "FTPbox - Missing File", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
                     if (dr == DialogResult.Cancel)
                         Process.GetCurrentProcess().Kill();
                 }
 
-                var param = string.Format("{0} {1} {2}", "FTPbox", newvers, downLink);
+                var param = string.Format("{0} {1} {2}", "FTPbox", Newvers, DownLink);
                 var pi = new ProcessStartInfo(pathtoupdater, param);
                 pi.Verb = "runas";
                 Process.Start(pi);
             }
-            catch { }
+            catch
+            {
+            }
 
             Process.GetCurrentProcess().Kill();
         }
@@ -66,7 +71,9 @@ namespace FTPbox
             {
                 Process.Start("http://ftpbox.org/changelog/");
             }
-            catch { }
+            catch
+            {
+            }
             Close();
         }
 
@@ -77,7 +84,7 @@ namespace FTPbox
 
         private void Set_Language(string lan)
         {
-            string qmark = "?";
+            var qmark = "?";
             if (lan == "el") qmark = ";";
 
             Text = "FTPbox | " + Common.Languages[UiControl.UpdateAvailable];

--- a/Windows/FTPbox/Forms/trayFormListItem.Designer.cs
+++ b/Windows/FTPbox/Forms/trayFormListItem.Designer.cs
@@ -6,7 +6,7 @@ using System.Windows.Forms;
 
 namespace FTPbox.Forms
 {
-    partial class trayFormListItem
+    sealed partial class trayFormListItem
     {
         /// <summary> 
         /// Required designer variable.

--- a/Windows/FTPbox/Forms/trayFormListItem.cs
+++ b/Windows/FTPbox/Forms/trayFormListItem.cs
@@ -4,17 +4,17 @@ using System.Windows.Forms;
 
 namespace FTPbox.Forms
 {
-    public partial class trayFormListItem : UserControl
+    public sealed partial class trayFormListItem : UserControl
     {
         public trayFormListItem()
         {
             InitializeComponent();
-            
-            this.BackColor = Color.Transparent;
+
+            BackColor = Color.Transparent;
         }
 
         /// <summary>
-        /// The name of the file this recent item refers to
+        ///     The name of the file this recent item refers to
         /// </summary>
         public string FileNameLabel
         {
@@ -26,17 +26,20 @@ namespace FTPbox.Forms
         }
 
         /// <summary>
-        /// The status of the item, will either include transfer status or last modified time
+        ///     The status of the item, will either include transfer status or last modified time
         /// </summary>
-        public string FileStatusLabel { set { lStatusLabel.Text = value; } }        
+        public string FileStatusLabel
+        {
+            set { lStatusLabel.Text = value; }
+        }
 
         /// <summary>
-        /// The format of the status label when the item is being transfered, ie 'Downloading {0}'
+        ///     The format of the status label when the item is being transfered, ie 'Downloading {0}'
         /// </summary>
         public string SubTitleFormat { get; set; }
 
         /// <summary>
-        /// Make sure Click is raised no matter where the user clicks
+        ///     Make sure Click is raised no matter where the user clicks
         /// </summary>
         public new event EventHandler Click
         {

--- a/Windows/FTPbox/Win32.cs
+++ b/Windows/FTPbox/Win32.cs
@@ -37,13 +37,13 @@ namespace FTPbox
         [StructLayout(LayoutKind.Sequential)]
         private struct SHFILEINFO
         {
-            public IntPtr hIcon;
-            public IntPtr iIcon;
-            public uint dwAttributes;
+            public readonly IntPtr hIcon;
+            public readonly IntPtr iIcon;
+            public readonly uint dwAttributes;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
-            public string szDisplayName;
+            public readonly string szDisplayName;
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
-            public string szTypeName;
+            public readonly string szTypeName;
         };
 
         #endregion


### PR DESCRIPTION
Changed from the obsolete PasswordDeriveBytes to the recommended Rfc2898DeriveBytes for more secure password encryption. Increased the iterations from 2 to 1000 (minimum recommended). Details about the differences here: http://blogs.msdn.com/b/shawnfa/archive/2004/04/14/generating-a-key-from-a-password.aspx

Harmonized the syntax according to best practices and conventions (variable names, method names, etc.)

Replaced explicit data type declarations with "Var" where possible to simplify the syntax, reduce clutter and improve code readability.

Fixed some cases where a NullReferenceException could be thrown (there was no check for nulls before accessing the objects).
